### PR TITLE
Stop using #Firestorm folder and LSL bridge

### DIFF
--- a/indra/llinventory/llfoldertype.h
+++ b/indra/llinventory/llfoldertype.h
@@ -99,6 +99,7 @@ public:
         FT_FIRESTORM = 58,
         FT_PHOENIX = 59,
         FT_RLV = 60,
+        FT_APERTURE = 61,
         // </FS:Ansariel> Folder types for our own virtual system folders
 
         FT_MY_SUITCASE = 100, // <FS:Ansariel> OpenSim HG-support

--- a/indra/newview/app_settings/settings_per_account.xml
+++ b/indra/newview/app_settings/settings_per_account.xml
@@ -1684,7 +1684,7 @@
         <key>Type</key>
             <string>Boolean</string>
         <key>Value</key>
-            <integer>1</integer>
+            <integer>0</integer>
         </map>
     <key>floater_rect_animation_overrider_full</key>
         <map>
@@ -1709,7 +1709,7 @@
         <key>Type</key>
             <string>Boolean</string>
         <key>Value</key>
-            <integer>1</integer>
+            <integer>0</integer>
         </map>
     <key>LockWearableFavoritesFolders</key>
       <map>
@@ -1718,7 +1718,7 @@
         <key>Type</key>
             <string>Boolean</string>
         <key>Value</key>
-            <integer>1</integer>
+            <integer>0</integer>
       </map>
 
 	<key>FSKeywordOn</key>

--- a/indra/newview/fs_resources/EBEDD1D2-A320-43f5-88CF-DD47BBCA5DFB.lsltxt
+++ b/indra/newview/fs_resources/EBEDD1D2-A320-43f5-88CF-DD47BBCA5DFB.lsltxt
@@ -1,5 +1,5 @@
 // HTTP Bridge script
-// Firestorm
+// Aperture | Firestorm
 // Tozh Taurog, Arrehn Oberlander, Tonya Souther
 
 //
@@ -77,7 +77,7 @@ aoListenOC(key collarid, integer enabled)
 
 aoState(string newstate)
 {
-    llOwnerSay("<clientAO state="+newstate+">");
+    llOwnerSay("<AVclientAO state="+newstate+">");
 }
 
 integrationCheckOC()
@@ -199,7 +199,7 @@ default
             // Check VM version
             if (llGetMemoryLimit() <= 16384)
             {
-                llOwnerSay("<bridgeError error=wrongvm>");
+                llOwnerSay("<AVbridgeError error=wrongvm>");
             }
 
             // Set the channel for the AO OC interface
@@ -310,7 +310,7 @@ default
             integer n = llGetInventoryNumber(INVENTORY_SCRIPT);
             if (n > 1)
             {
-                llOwnerSay("<bridgeError error=injection>");
+                llOwnerSay("<AVbridgeError error=injection>");
                 llSleep(1.0);
                 while (n)
                 {
@@ -394,7 +394,7 @@ default
             if (gViewerIsFirestorm || gTryHandshakeOnce)
             {
                 // Firestorm viewer and handshake
-                llOwnerSay("<bridgeURL>" + gLatestURL + "</bridgeURL><bridgeAuth>BRIDGEKEY</bridgeAuth><bridgeVer>" + BRIDGE_VERSION + "</bridgeVer>");
+                llOwnerSay("<AVbridgeURL>" + gLatestURL + "</AVbridgeURL><AVbridgeAuth>BRIDGEKEY</AVbridgeAuth><AVbridgeVer>" + BRIDGE_VERSION + "</AVbridgeVer>");
                 gTryHandshakeOnce = FALSE;
             }
             else
@@ -407,7 +407,7 @@ default
         else if (Method == URL_REQUEST_DENIED)
         {
             // No URLs free! Keep trying?
-            llOwnerSay("<bridgeRequestError/>");
+            llOwnerSay("<AVbridgeRequestError/>");
             llSleep(5);
             requestBridgeURL();
         }
@@ -456,7 +456,7 @@ default
                 movelockMe(gUseMoveLock);
                 if (llList2String(commandList, 2) != "noreport")
                 {
-                    llOwnerSay("<bridgeMovelock state=" + (string)gUseMoveLock + ">");
+                    llOwnerSay("<AVbridgeMovelock state=" + (string)gUseMoveLock + ">");
                 }
             }
 
@@ -519,11 +519,11 @@ default
                     {
                         returnedList = returnedList + [llStringToBase64(llStringTrim(llList2String(details, 6), STRING_TRIM)), llList2String(details, 7), llList2Integer(details, 8), llList2Integer(details, 9), llList2Integer(details, 10), llStringToBase64(llList2String(details, 11)), llStringToBase64(llList2String(details, 12) + " (" + (string)llVecDist(llList2Vector(details, 12), currentPosition) + " m)"), llStringToBase64(llList2String(details, 13) + " (" + (string)(RAD_TO_DEG * llRot2Euler(llList2Rot(details, 13))) + ")"), llStringToBase64(llList2String(details, 14)), llList2Key(details, 15), llList2Key(details, 16), llList2Key(details, 17), llList2Key(details, 18), llList2Key(details, 19), llList2String(details, 20), llList2String(details, 21), llList2Integer(details, 22), llList2Integer(details, 23), llList2Integer(details, 24), llStringToBase64(llList2String(details, 25)), llList2Key(details, 26)];
                     }
-                    llOwnerSay("<bridgeGetScriptInfo>" + llList2CSV(returnedList) + "</bridgeGetScriptInfo>");
+                    llOwnerSay("<AVbridgeGetScriptInfo>" + llList2CSV(returnedList) + "</bridgeGetScriptInfo>");
                 }
                 else
                 {
-                    llOwnerSay("<bridgeError error=scriptinfonotfound>");
+                    llOwnerSay("<AVbridgeError error=scriptinfonotfound>");
                 }
 
             }
@@ -581,7 +581,7 @@ default
             else if (cmd == "DetachBridge")
             {
                 // HTTP request from the viewer to immediately detach LSL-Client Bridge
-                // This can be passed as a response to llOwnerSay("<bridgeURL> ... </bridgeVer>") handshake right after granting URL by a region
+                // This can be passed as a response to llOwnerSay("<AVbridgeURL> ... </bridgeVer>") handshake right after granting URL by a region
                 // If bridge doesn't receive "URL Confirmed" message as a reply to handshake it'll automatically detach after next region change anyway
                 detachBridge();
             }

--- a/indra/newview/fslslbridge.cpp
+++ b/indra/newview/fslslbridge.cpp
@@ -182,7 +182,7 @@ bool FSLSLBridge::lslToViewer(std::string_view message, const LLUUID& fromID, co
 
     bool bridgeIsEnabled = gSavedSettings.getBOOL("UseLSLBridge");
     bool status = false;
-    if (tag == "<bridgeURL>")
+    if (tag == "<AVbridgeURL>")
     {
         if (!bridgeIsEnabled)
         {
@@ -191,15 +191,15 @@ bool FSLSLBridge::lslToViewer(std::string_view message, const LLUUID& fromID, co
         }
 
         // brutish parsing
-        static const std::string bridge_url_tag = "<bridgeURL>";
-        static const std::string bridge_auth_tag = "<bridgeAuth>";
-        static const std::string bridge_ver_tag = "<bridgeVer>";
+        static const std::string bridge_url_tag = "<AVbridgeURL>";
+        static const std::string bridge_auth_tag = "<AVbridgeAuth>";
+        static const std::string bridge_ver_tag = "<AVbridgeVer>";
         size_t urlStart  = message.find(bridge_url_tag) + bridge_url_tag.size();
-        size_t urlEnd    = message.find("</bridgeURL>");
+        size_t urlEnd    = message.find("</AVbridgeURL>");
         size_t authStart = message.find(bridge_auth_tag) + bridge_auth_tag.size();
-        size_t authEnd   = message.find("</bridgeAuth>");
+        size_t authEnd   = message.find("</AVbridgeAuth>");
         size_t verStart  = message.find(bridge_ver_tag) + bridge_ver_tag.size();
-        size_t verEnd    = message.find("</bridgeVer>");
+        size_t verEnd    = message.find("</AVbridgeVer>");
         std::string bURL = static_cast<std::string>(message.substr(urlStart,urlEnd - urlStart));
         std::string bAuth = static_cast<std::string>(message.substr(authStart,authEnd - authStart));
         std::string bVer = static_cast<std::string>(message.substr(verStart,verEnd - verStart));
@@ -304,7 +304,7 @@ bool FSLSLBridge::lslToViewer(std::string_view message, const LLUUID& fromID, co
 
         return true;
     }
-    else if (tag == "<bridgeRequestError/>")
+    else if (tag == "<AVbridgeRequestError/>")
     {
         LL_WARNS("FSLSLBridge") << "Could not obtain URL for LSL bridge." << LL_ENDL;
         return true;
@@ -395,11 +395,11 @@ bool FSLSLBridge::lslToViewer(std::string_view message, const LLUUID& fromID, co
     //</FS:TS> FIRE-962
 
     // <FS:PP> Get script info response
-    else if (tag == "<bridgeGetScriptInfo>")
+    else if (tag == "<AVbridgeGetScriptInfo>")
     {
         size_t tag_size = tag.size();
         status = true;
-        size_t getScriptInfoEnd = message.find("</bridgeGetScriptInfo>");
+        size_t getScriptInfoEnd = message.find("</AVbridgeGetScriptInfo>");
         if (getScriptInfoEnd != std::string::npos)
         {
             std::string getScriptInfoString = static_cast<std::string>(message.substr(tag_size, getScriptInfoEnd - tag_size));
@@ -495,7 +495,7 @@ bool FSLSLBridge::lslToViewer(std::string_view message, const LLUUID& fromID, co
     // </FS:PP>
 
     // <FS:PP> Movelock state response
-    else if (tag == "<bridgeMovelock ")
+    else if (tag == "<AVbridgeMovelock ")
     {
         status = true;
         size_t valuepos = message.find(FS_STATE_ATTRIBUTE);
@@ -518,7 +518,7 @@ bool FSLSLBridge::lslToViewer(std::string_view message, const LLUUID& fromID, co
     // </FS:PP>
 
     // <FS:PP> Error responses handling
-    else if (tag == "<bridgeError ")
+    else if (tag == "<AVbridgeError ")
     {
         status = true;
         size_t valuepos = message.find(FS_ERROR_ATTRIBUTE);

--- a/indra/newview/fslslbridge.h
+++ b/indra/newview/fslslbridge.h
@@ -36,7 +36,7 @@
 class FSLSLBridgeRequestResponder;
 
 const std::string LIB_ROCK_NAME = "Rock - medium, round";
-const std::string FS_BRIDGE_NAME = "#Firestorm LSL Bridge v";
+const std::string FS_BRIDGE_NAME = "#Aperture LSL Bridge v";
 const U8 FS_BRIDGE_POINT = 31;
 const std::string FS_BRIDGE_ATTACHMENT_POINT_NAME = "Center 2";
 

--- a/indra/newview/llinventorybridge.cpp
+++ b/indra/newview/llinventorybridge.cpp
@@ -4100,8 +4100,9 @@ LLFolderType::EType LLFolderBridge::getPreferredType() const
         //               folders, which is not desired.
         //preferred_type = cat->getPreferredType();
         std::string catName(cat->getName());
-        if (catName == ROOT_FIRESTORM_FOLDER) preferred_type = LLFolderType::FT_FIRESTORM;
+        if (catName == ROOT_FIRESTORM_FOLDER) preferred_type = LLFolderType::FT_APERTURE;
         else if (catName == RLV_ROOT_FOLDER) preferred_type = LLFolderType::FT_RLV;
+        else if (catName == "#Firestorm") preferred_type = LLFolderType::FT_FIRESTORM;
         else if (catName == "#Phoenix") preferred_type = LLFolderType::FT_PHOENIX;
         else preferred_type = cat->getPreferredType();
         // </FS:Ansariel>

--- a/indra/newview/llinventoryfunctions.h
+++ b/indra/newview/llinventoryfunctions.h
@@ -38,7 +38,7 @@ const S32 COMPUTE_STOCK_INFINITE = -1;
 const S32 COMPUTE_STOCK_NOT_EVALUATED = -2;
 
 // <FS:TT> - Firestorm folder name for use by AO, bridge and possibly others
-#define ROOT_FIRESTORM_FOLDER   "#Firestorm"
+#define ROOT_FIRESTORM_FOLDER   "#Aperture"
 // </FS:TT>
 
 /********************************************************************************

--- a/indra/newview/llviewerfoldertype.cpp
+++ b/indra/newview/llviewerfoldertype.cpp
@@ -179,6 +179,7 @@ LLViewerFolderDictionary::LLViewerFolderDictionary()
     addEntry(LLFolderType::FT_NONE,                 new ViewerFolderEntry("New Folder",             "Inv_FolderOpen",       "Inv_FolderClosed",     false,     false, "default"));
 
     // <FS:Ansariel> Special Firestorm folder
+    addEntry(LLFolderType::FT_APERTURE,             new ViewerFolderEntry("Aperture",               "Inv_SysOpen",          "Inv_SysClosed",        false,     true));
     addEntry(LLFolderType::FT_FIRESTORM,            new ViewerFolderEntry("Firestorm",              "Inv_FirestormOpen",    "Inv_FirestormClosed",  false,     true));
     addEntry(LLFolderType::FT_PHOENIX,              new ViewerFolderEntry("Phoenix",                "Inv_PhoenixOpen",      "Inv_PhoenixClosed",    false,     true));
     addEntry(LLFolderType::FT_RLV,                  new ViewerFolderEntry("RLV",                    "Inv_RLVOpen",          "Inv_RLVClosed",        false,     true));

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -996,6 +996,7 @@ If you continue to receive this message, please contact Second Life support for 
 	<string name="InvFolder All">All</string>
 
 	<!-- Virtual Firestorm system folders -->
+	<string name="InvFolder #Aperture">#Aperture</string>
 	<string name="InvFolder #Firestorm">#Firestorm</string>
 	<string name="InvFolder #Phoenix">#Phoenix</string>
 	<string name="InvFolder #RLV">#RLV</string>


### PR DESCRIPTION
This PR replaces the #Firestorm inventory folder and the LSL bridge with a new #Aperture folder and LSL bridge. The new bridge uses an incompatible communication schema to avoid cross contact, and further separates Aperture from Firestorm such that new bridge features can be added at a later date if desired without disruption or conflict for users using multiple viewers.

This creates an opportunity / need for new artwork, please see the references for Inv_SysOpen and Inv_SysClosed in `indra/newview/llviewerfoldertype.cpp` with which I would recommend furnishing with a branded folder icon set.