### PR TITLE
Fixes: Correct default constraints in featuretable_aperture.txt

### DIFF
--- a/indra/newview/featuretable_aperture.txt
+++ b/indra/newview/featuretable_aperture.txt
@@ -52,7 +52,7 @@ RenderHDREnabled                                    1 1     // HDR Pipeline ON
 RenderEnableEmissiveBuffer                          1 1     // Emmisive Enablement
 RenderExposure                                      1 1.0   // Neutral Exposure default
 RenderTonemapType                                   1 1     // ACES Tonemapping default
-RenderTonemapMix                                    1 0.0   // Default Tonemap Mix
+RenderTonemapMix                                    1 1.0   // Default Tonemap Mix
 
 // Legacy Sky Auto-Adjustment Settings
 RenderSkyAutoAdjustLegacy                           1 1     // fOR level 0 = 0. 
@@ -62,7 +62,7 @@ RenderTerrainPBRDetail                              1 0     // 0 is highest and 
 RenderTerrainPBRPlanarSampleCount                   1 3     // for level 0 set to 1
 
 // Basic Lighting
-RenderLocalLightCount                               1 16   // Number of local lights to render
+RenderLocalLightCount                               1 8192   // Number of local lights to render
 RenderShaderLightingMaxLevel                        1 3     // Enable All Local Light Shadows 1 - S/M, 2 Redueced, 3 Full
 
 // Basic Texture Handling
@@ -70,9 +70,9 @@ RenderAnisotropic                                   1 1     // Anisotropic Filte
 RenderCompressTextures                              1 1     // Compression OFF (Max Quality) - We leave on for Level set to 1 for level 0
 
 // Reflection Probe Enablement & Quality (Fundamental for PBR/HDR lighting)
-RenderReflectionProbeResolution                     1 256  // High Probe Resolution (Restart) - Aperture feautre only - 1024 and 2048 (set at 64 for default and test VRAM impact of candy - 512 might be best)
+RenderReflectionProbeResolution                     1 2048  // High Probe Resolution (Restart) - Aperture feautre only - 1024 and 2048 (set at 64 for default and test VRAM impact of candy - 512 might be best)
 RenderReflectionProbeLevel                          1 3     // Full Scene Coverage - we set to 3 from level 1
-RenderReflectionProbeDrawDistance                   1 32  // Generous Draw Distance - maybe set to 32 and candy at 256 or 512/1024
+RenderReflectionProbeDrawDistance                   1 1024  // Generous Draw Distance - maybe set to 32 and candy at 256 or 512/1024
 RenderReflectionProbeMaxLocalLightAmbiance          1 4.0   // Default Max Local Ambience - never changing here - just in case user changes we want to reset it here
 RenderReflectionProbeDetail                         1 2     // -1 - Disabled, 0 - Static Only, 1 - Static + Dynamic, 2 - Realtime
 RenderReflectionsEnabled                            1 1     // Base Toggle for Reflection Probes ON - Depreciated?! think still needed for single function
@@ -80,7 +80,7 @@ RenderReflectionsEnabled                            1 1     // Base Toggle for R
 // Glow Enablement & Quality
 RenderGlow                                          1 1     // Glow ON
 RenderGlowHDR                                       1 1     // HDR Glow ON
-RenderGlowResolutionPow                             1 10    // High Glow Quality
+RenderGlowResolutionPow                             1 13    // High Glow Quality
 RenderGlowIterations                                1 2     // Moderate Glow Iterations
 RenderGlowStrength                                  1 0.325 // Subtle Glow Strength default
 RenderGlowWidth                                     1 1.3   // Moderate Glow Width default
@@ -98,7 +98,7 @@ RenderWaterMaterials                                1 1     // Water reflects ma
 RenderShadowDetail                                  1 2     // Sun/Moon + Projectors
 
 // Shadow Quality Details (High Defaults for 'all')
-RenderShadowResolutionScale                         1 1.0   // High Shadow Map Resolution
+RenderShadowResolutionScale                         1 4.0   // High Shadow Map Resolution
 RenderShadowSplits                                  1 3     // Default Cascades
 RenderShadowBlurSize                                1 1.4   // Moderate Shadow Blur
 RenderShadowBlurDistFactor                          1 0.08   // Default Blur Distance Factor
@@ -111,7 +111,7 @@ RenderDeferredSSAO                                  1 1     // SSAO ON
 
 // SSAO REQUIRES SOME THOUGHT - We need a high rez mode
 // SSAO Quality Details (High Defaults for 'all')
-APRenderSSAOSampleCount                             1 8      // High SSAO Samples - we need to think about how do deal with AO overal, for now I think we leave these defaults
+APRenderSSAOSampleCount                             1 1024      // High SSAO Samples - we need to think about how do deal with AO overal, for now I think we leave these defaults
 RenderSSAOScale                                     1 500.0  // Default Scale?
 RenderSSAOMaxScale                                  1 200.0  // Default Max Scale?
 RenderSSAOFactor                                    1 1      // Default Factor?
@@ -123,12 +123,12 @@ RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Sca
 RenderDepthOfField                                  1 1     // DoF ON
 
 // DoF Quality & Behavior (High Defaults for 'all')
-CameraFocusTransitionTime                           1 0.0   // Default Focus Transition
+CameraFocusTransitionTime                           1 5.0   // Default Focus Transition
 CameraFNumber                                       1 9.0   // Medium f-stop default
-CameraFocalLength                                   1 50.0  // Standard Lens default
+CameraFocalLength                                   1 500.0  // Standard Lens default
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
-CameraMaxCoF                                        1 10.0  // Default CoC Amount
-CameraDoFResScale                                   1 0.7   // Max DoF Resolution
+CameraMaxCoF                                        1 150.0  // Default CoC Amount
+CameraDoFResScale                                   1 1.0   // Max DoF Resolution
 
 // --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
 // SSR Enablement
@@ -144,14 +144,14 @@ RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Sampl
 RenderMirrors                                       1 1     // Mirrors ON
 
 // Mirror Quality Details (High Defaults for 'all')
-RenderHeroProbeResolution                           1 128  // High Mirror Resolution - now 8192 is possible just rdiiculous
+RenderHeroProbeResolution                           1 8192  // High Mirror Resolution - now 8192 is possible just rdiiculous
 RenderHeroProbeUpdateRate                           1 6     // Fast Mirror Update Rate
 
 // --- LEVELS 7/8: GENERAL QUALITY / PHOTOTOOLS GEN TAB / CANDY LEVEL ADJUSTMENTS ---
 // General Performance / Quality Trade-offs (High Defaults for 'all')
-RenderFarClip                                       1 256   // Draw Distance
+RenderFarClip                                       1 4096   // Draw Distance
 FramePerSecondLimit                                 1 60     // FPS Limit (0=Unlimited) - think carefully about this, it might be best to set it even to 30
-RenderMaxPartCount                                  1 1024   // Particle Count - we will set this to 1024 for all levels below candy and off for level 0
+RenderMaxPartCount                                  1 8192   // Particle Count - we will set this to 1024 for all levels below candy and off for level 0
 RenderAvatarComplexityMode                          1 0      /// 0 - complexity limit applies to everyone, 1 - always show friends, 2 - only show friends
 RenderAvatarMaxComplexity                           1 0      // Avatar Complexity Max
 RenderAvatarMaxNonImpostors                         1 16     // Max Fully Rendered Avatars
@@ -175,11 +175,11 @@ TextureCameraBoost                                  1 8     // Tex Boost Near Ca
 RenderAutoMuteSurfaceAreaLimit                      1 10.0  // Leaving in for now - ONLY TEMP - Must investigate if there is any need or benefit to changing this value
 
 // Anti-Aliasing Quality (High Defaults for 'all' - applied if Type is not 0)
-RenderFSAAType                                      1 0     // Type of Antialiasing to use: 0 = None, 1 = FXAA, 2 = SMAA
+RenderFSAAType                                      1 2     // Type of Antialiasing to use: 0 = None, 1 = FXAA, 2 = SMAA
 RenderFSAASamples                                   1 3     // AA Quality (Ultra)
 
 // Sharpening (Default)
-RenderCASSharpness                                  1 0.4   // Moderate Sharpening
+RenderCASSharpness                                  1 1.0   // Moderate Sharpening
 
 // Attached Lights
 RenderAttachedLights                                1 1     // Attached Lights ON
@@ -1669,7 +1669,7 @@ RenderTerrainPBRDetail                              1 0     // 0 is highest and 
 RenderTerrainPBRPlanarSampleCount                   1 3     // for level 0 set to 1
 
 // Basic Lighting
-RenderLocalLightCount                               1 256   // Number of local lights to render
+RenderLocalLightCount                               1 8192   // Number of local lights to render
 RenderShaderLightingMaxLevel                        1 3     // Enable All Local Light Shadows 1 - S/M, 2 Redueced, 3 Full
 
 // Basic Texture Handling
@@ -1862,7 +1862,7 @@ RenderTerrainPBRDetail                              1 0     // 0 is highest and 
 RenderTerrainPBRPlanarSampleCount                   1 3     // for level 0 set to 1
 
 // Basic Lighting
-RenderLocalLightCount                               1 256   // Number of local lights to render
+RenderLocalLightCount                               1 8192   // Number of local lights to render
 RenderShaderLightingMaxLevel                        1 3     // Enable All Local Light Shadows 1 - S/M, 2 Redueced, 3 Full
 
 // Basic Texture Handling


### PR DESCRIPTION
**Resolves:** Fixes #7

**Problem:**
As reported in Issue #7, the default `RenderLocalLightCount` was unintentionally constrained to a low value (e.g., 16 or 256) even when selecting higher graphics preset levels (`AP_Level_*`). Further investigation revealed this issue also affected several other key quality settings, preventing the higher presets from applying their intended maximum/tuned values defined in the `[all]` section or their specific level overrides within `featuretable_aperture.txt`.

**Solution:**
This PR corrects the default values for numerous rendering settings within `featuretable_aperture.txt`, primarily impacting the defaults inherited by higher preset levels. This ensures that selecting presets like "Level 8 - Eye Candy" correctly applies appropriate high-quality defaults, aligning with user expectations and the design intent. Lower preset levels remain constrained as intended for performance balancing.

Key settings addressed include (but are not limited to): `RenderLocalLightCount`, `RenderReflectionProbeResolution`, `RenderReflectionProbeDrawDistance`, `RenderGlowResolutionPow`, `RenderShadowResolutionScale`, `APRenderSSAOSampleCount`, `RenderHeroProbeResolution`, `RenderFarClip`, `RenderMaxPartCount`, various DoF parameters, `RenderFSAAType`, `RenderCASSharpness`, and `RenderTonemapMix`.

---

**QA - Testing Criteria:**

**Goal:** Verify that selecting different `AP_Level_*` graphics presets correctly applies the *specific* settings and values defined for **that exact level** within `featuretable_aperture.txt` (as reflected in the Phototools UI). Crucially, confirm that changes made to the `[all]` defaults section have correctly influenced the highest selectable preset (Level 8) where appropriate, but have **not** unintentionally altered the settings of lower preset levels (e.g., Level 1, 3, 5). Ensure viewer stability.

**Environment:** Launch Aperture Viewer build from this branch (`fix/issue-7-light-defaults`). Open Aperture Phototools Suite (Ctrl+Shift+P). Use a scene suitable for observation.

**Test Steps & Pass/Fail Criteria:**

**(A) Test Level 0: Essential Visuals (Baseline OFF)**
1.  **Action:** Select `Essential Features` (Level 0) in Phototools -> Gen tab.
2.  **Verify Settings via Phototools UI (Values from `list AP_Level_0_Essential_Visuals`):**
    *   HDR (Post): `Enable HDR` = Unchecked.
    *   Shadows (Shd): `Shadow Types` = "None" (0).
    *   SSAO (Shd): `Enable SSAO` = Unchecked.
    *   DoF (Lens): `Enable DoF` = Unchecked.
    *   SSR (Refl): `Enable SSR` = Unchecked.
    *   Mirrors (Refl): `Enable Mirrors` = Unchecked.
    *   Local Lights (Shd): `Loc Lights` spinner = 8.
    *   Draw Distance (Gen): `Draw Dist` spinner = 64.
    *   **Pass/Fail:** All values must match Level 0 definitions.

**(B) Test Level 1: HDR Foundation (Check *against* high `[all]` defaults)**
1.  **Action:** Select `Basic HDR & Effects` (Level 1) in Phototools -> Gen tab.
2.  **Verify Settings via Phototools UI (Values from `list AP_Level_1_HDR_Foundation`):**
    *   HDR (Post): `Enable HDR` = Checked.
    *   Shadows (Shd): `Shadow Types` = "None" (0).
    *   SSAO (Shd): `Enable SSAO` = Unchecked.
    *   Local Lights (Shd): `Loc Lights` spinner = **256**. **Pass:** Is 256. **Fail:** Is 8192 (unintended inheritance from `[all]`).
    *   Probe Res (Refl): `Probe Resolution` = **128**. **Pass:** Is 128. **Fail:** Is 2048 (unintended inheritance).
    *   Probe Draw (Refl): `Reflect. Dist.` spinner = **1024**. **Pass:** Is 1024. **Fail:** Is different.
    *   Glow Res Pow (Lens): Use Debug `RenderGlowResolutionPow`. **Pass:** Is 10. **Fail:** Is 13 (unintended inheritance).
    *   Draw Distance (Gen): `Draw Dist` spinner = **256**. **Pass:** Is 256. **Fail:** Is 4096 (unintended inheritance).
    *   **Pass/Fail:** Settings must match Level 1 definitions, specifically *not* adopting the higher values from the `[all]` section modifications.

**(C) Test Level 3: SSAO (Check *against* high `[all]` defaults)**
1.  **Action:** Select `Ambient Occlusion` (Level 3) in Phototools -> Gen tab.
2.  **Verify Settings via Phototools UI (Values from `list AP_Level_3_SSAO`):**
    *   Shadows (Shd): `Shadow Types` = "Sun/Moon + Projectors" (2).
    *   SSAO (Shd): `Enable SSAO` = Checked.
    *   SSAO Samples (Shd): `Samples` spinner = **8**. **Pass:** Is 8. **Fail:** Is 1024 (unintended inheritance).
    *   Shadow Res (Shd): `Shd. Res` spinner = **1.0**. **Pass:** Is 1.0. **Fail:** Is 4.0 (unintended inheritance).
    *   Local Lights (Shd): `Loc Lights` spinner = **256**. **Pass:** Is 256. **Fail:** Is 8192.
    *   Probe Res (Refl): `Probe Resolution` = **128**. **Pass:** Is 128. **Fail:** Is 2048.
    *   Draw Distance (Gen): `Draw Dist` spinner = **256**. **Pass:** Is 256. **Fail:** Is 4096.
    *   **Pass/Fail:** Settings must match Level 3 definitions, specifically *not* adopting the higher values from the `[all]` section modifications.

**(D) Test Level 5: SSR (Check *against* high `[all]` defaults)**
1.  **Action:** Select `Screen Space Reflections` (Level 5) in Phototools -> Gen tab.
2.  **Verify Settings via Phototools UI (Values from `list AP_Level_5_SSR`):**
    *   DoF (Lens): `Enable DoF` = Checked.
    *   SSR (Refl): `Enable SSR` = Checked.
    *   Mirrors (Refl): `Enable Mirrors` = Unchecked.
    *   Local Lights (Shd): `Loc Lights` spinner = **256**. **Pass:** Is 256. **Fail:** Is 8192.
    *   SSAO Samples (Shd): `Samples` spinner = **8**. **Pass:** Is 8. **Fail:** Is 1024.
    *   Probe Res (Refl): `Probe Resolution` = **128**. **Pass:** Is 128. **Fail:** Is 2048.
    *   Draw Distance (Gen): `Draw Dist` spinner = **256**. **Pass:** Is 256. **Fail:** Is 4096.
    *   DoF CoC (Lens): `CoC` spinner = **10.0**. **Pass:** Is 10.0. **Fail:** Is 150.0 (unintended inheritance).
    *   DoF Res Scale (Lens): Use Debug `CameraDoFResScale`. **Pass:** Is 0.7. **Fail:** Is 1.0 (unintended inheritance).
    *   **Pass/Fail:** Settings must match Level 5 definitions, specifically *not* adopting the higher values from the `[all]` section modifications.

**(E) Test Level 8: Eye Candy - with Mirrors (Check *specific* values, comparing to `[all]` where needed)**
1.  **Action:** Select `Eye Candy - with Mirrors` (Level 8) in Phototools -> Gen tab.
2.  **Verify Settings via Phototools UI (Values from `list AP_Level_8_Full_Candy`):**
    *   Mirrors (Refl): `Enable Mirrors` = Checked.
    *   Local Lights (Shd): `Loc Lights` spinner = **8192**. **Pass:** Is 8192 (Matches new `[all]` default). **Fail:** Is not 8192.
    *   SSAO Samples (Shd): `Samples` spinner = **18**. **Pass:** Is 18 (*Overrides* new `[all]` default of 1024). **Fail:** Is not 18.
    *   Probe Res (Refl): `Probe Resolution` = **512**. **Pass:** Is 512 (*Overrides* new `[all]` default of 2048). **Fail:** Is not 512.
    *   Probe Draw (Refl): `Reflect. Dist.` spinner = **1024**. **Pass:** Is 1024 (Matches new `[all]` default). **Fail:** Is not 1024.
    *   Draw Distance (Gen): `Draw Dist` spinner = **1024**. **Pass:** Is 1024 (*Overrides* new `[all]` default of 4096). **Fail:** Is not 1024.
    *   Shadow Res (Shd): `Shd. Res` spinner = **1.0**. **Pass:** Is 1.0 (*Overrides* new `[all]` default of 4.0). **Fail:** Is not 1.0.
    *   Mirror Res (Refl): `Mirror Resolution` = **4096**. **Pass:** Is 4096 (*Overrides* new `[all]` default of 8192). **Fail:** Is not 4096.
    *   Particles (Gen): `Particle Cnt` spinner = **4096**. **Pass:** Is 4096 (*Overrides* new `[all]` default of 8192). **Fail:** Is not 4096.
    *   DoF CoC (Lens): `CoC` spinner = **30.0**. **Pass:** Is 30.0 (*Overrides* new `[all]` default of 150.0). **Fail:** Is not 30.0.
    *   AA Type (Gen): `Antialiasing Type` = **SMAA**. **Pass:** Is SMAA (Matches new `[all]` default). **Fail:** Not SMAA.
    *   Sharpening (Post): `Sharpening` spinner = **0.4**. **Pass:** Is 0.4 (*Overrides* new `[all]` default of 1.0). **Fail:** Not 0.4.
    *   Tone Mix (Post): `Tone Mix` spinner = **0.0**. **Pass:** Is 0.0 (*Overrides* new `[all]` default of 1.0). **Fail:** Not 0.0.
3.  **Visual Check:** All features ON, quality high but reflecting the *specific* overrides of Level 8.
4.  **Stability Check:** Move around, interact. **Pass:** Stable. **Fail:** Crash/Unresponsive.

**(F) Final Preset Switching Check**
1.  **Action:** Switch between several levels (e.g., 8 -> 1 -> 5 -> 0).
2.  **Verify via Phototools UI:** Spot-check a key changed setting (like `Loc Lights`) after each switch to ensure it updates correctly to the value expected for *that specific level*.
3.  **Result:** **Pass:** Settings update correctly per selected level. **Fail:** Settings get stuck or apply incorrectly.

**Overall Pass/Fail:** The test passes if *all* individual verification steps pass for *all* tested levels.