### PR TITLE
Fixes: Correct Name Tag Display functionality in Phototools floater

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
+++ b/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
@@ -7982,7 +7982,7 @@
              top_pad="0"
              left="0"
              width="286"
-             height="110" 
+             height="132" 
              border_visible="false"
              bevel_style="none"
              background_visible="true">


### PR DESCRIPTION
This PR addresses Issue #9.

The "Name Tag Display" dropdown control within the Aperture Phototools floater was not working as expected. Users were unable to change the name tag display settings using this dropdown, and attempts to interact with it could inadvertently change the UI Scale setting.

This commit resolves the XUI layout issues in `floater_ap_phototools.xml` to ensure the dropdown functions correctly.

Fixes #9

---
**Testing Instructions for QA:**

1.  Build the viewer from the `fix/issue-9-phototools-nametag` branch.
2.  Open the Aperture Phototools floater.
3.  Locate the "Name Tag Display" dropdown.
4.  **Verify:** You can now select different options (On, Off, Show Temporarily) from the dropdown, and observe that the name tags in-world update correctly according to your selection.
5.  **Verify:** After changing the setting via Phototools, close and reopen the Phototools floater. The selected setting should persist in the dropdown.
6.  **Verify:** Interacting with the "Name Tag Display" dropdown (clicking it, changing selections) *does not* cause any accidental changes to the UI Scale slider/value.
7.  (Optional) If the "Name Tag Display" setting in the main Preferences window (e.g., Preferences > General) is intended to be the same setting:
    *   Change the setting in Phototools and check if it's reflected in Preferences.
    *   Change the setting in Preferences and check if it's reflected in Phototools.

Please report any deviations or unexpected behavior.