### PR TITLE
Enhance: Default script dialog position to top-right (#11)

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -1119,7 +1119,7 @@
       <key>Type</key>
       <string>S32</string>
       <key>Value</key>
-      <integer>2</integer>
+      <integer>3</integer>
     </map>
 
   <key>DialogStackIconVisible</key>


### PR DESCRIPTION
This PR addresses Issue #11 by changing the default position for script dialogs.

User feedback indicated that the previous default (value `2`, likely TopLeft or similar) was less intuitive than Top-Right for script dialog popups. This change updates `settings.xml` to make Top-Right (`ScriptDialogsPosition = 3`) the new default.

Addresses #11 

---
**Testing Instructions for QA:**

1.  **IMPORTANT:** For this test, it's best to start with a **fresh user settings profile** or ensure you reset the `ScriptDialogsPosition` debug setting to its default value before launching the test build. (To reset: Debug Settings > type `ScriptDialogsPosition` > click "Reset to default" > close viewer > relaunch with test build).
2.  Launch the viewer built from the `enhance/issue-11-script-dialog-default` branch.
3.  Trigger a script dialog. Ways to do this:
    *   Rez a simple scripted prim that uses `llGiveInventory()`.
    *   Try to sit on an object that requires animation permissions.
    *   Pay a scripted vendor.
4.  **Verify:** The script dialog popup appears in the **top-right corner** of the viewer window by default.
5.  Go to Debug Settings (Ctrl-Alt-Shift-S) and search for `ScriptDialogsPosition`.
6.  **Verify:** The current value is `3`.
7.  Change `ScriptDialogsPosition` to `0` (Center, or whatever value corresponds to Center according to the comment in `settings.xml`). Trigger another script dialog.
8.  **Verify:** The dialog now appears in the center (or the chosen position).
9.  Test other valid values for `ScriptDialogsPosition` as documented in the setting's comment (e.g., `0`, `1`, `2`, `4` if they exist) to ensure they still work.
10. **Verify:** The dialog appears in the newly selected position for each test.

The key is to confirm the new *default* is Top-Right (value `3`), and that the setting remains user-configurable for all valid options. Check the comment for `ScriptDialogsPosition` in `settings.xml` to know what values map to which positions.