### PR TITLE
Fixed the installer script to use the proper LICENSE_PATH

### DIFF
--- a/indra/newview/installers/windows/installer_template.nsi
+++ b/indra/newview/installers/windows/installer_template.nsi
@@ -115,7 +115,7 @@ SetOverwrite on							# Overwrite files by default
 !define MSUNINSTALL_KEY "${MSCURRVER_KEY}\Uninstall\${INSTNAME}"
 
 # <AP:WW> Rebrand: Define LICENSE_PATH variable.
-!define LICENSE_PATH "E:/aperture/indra/newview/installers/windows"
+!define LICENSE_PATH "%%SOURCE%%/installers/windows"
 # </AP:WW>
 
 


### PR DESCRIPTION
This Pull Request aims to resolves the issue https://github.com/ApertureViewer/Aperture-Viewer/issues/19 file to the Aperture Viewer repository. 

The primary purpose of this PR is to resolve a bug with the packaging / NSI installer script where it will fail to build for self-compilers.

### Changelog
**Update**
- **Files**:
  -  [installer_template.nsi](indra/newview/installers/windows/installer_template.nsi) 
- **Actions taken**
  - changed the hardcoded value of `E:/.....` to use variable `%%SOURCE%%`

