### PR TITLE
[FEAT] Override Default Add friend, Teleport Messages

### DIFF
--- a/indra/newview/app_settings/settings_per_account.xml
+++ b/indra/newview/app_settings/settings_per_account.xml
@@ -2247,7 +2247,7 @@
         <key>Value</key>
             <array/>
         </map>
-        <key>AddFriendReponseChanged</key>
+        <key>APAddFriendReponseChanged</key>
         <map>
         <key>Comment</key>
             <string>Does the Add Friend message differ from the default?</string>
@@ -2258,7 +2258,7 @@
         <key>Value</key>
             <integer>0</integer>
         </map>
-        <key>AddFriendMessageResponse</key>
+        <key>APAddFriendMessageResponse</key>
         <map>
             <key>Comment</key>
             <string>Override the default add friend message</string>
@@ -2269,7 +2269,7 @@
             <key>Value</key>
             <string/>
         </map>
-        <key>TeleportRequestResponseChanged</key>
+        <key>APTeleportRequestResponseChanged</key>
         <map>
         <key>Comment</key>
             <string>Does the Teleport Request message differ from the default?</string>
@@ -2280,7 +2280,7 @@
         <key>Value</key>
             <integer>0</integer>
         </map>
-        <key>TeleportRequestMessageResponse</key>
+        <key>APTeleportRequestMessageResponse</key>
         <map>
             <key>Comment</key>
             <string>Override the default teleport offer message</string>
@@ -2291,7 +2291,7 @@
             <key>Value</key>
             <string/>
         </map>
-        <key>TeleportOfferResponseChanged</key>
+        <key>APTeleportOfferResponseChanged</key>
         <map>
         <key>Comment</key>
             <string>Does the Teleport offer message differ from the default?</string>
@@ -2302,7 +2302,7 @@
         <key>Value</key>
             <integer>0</integer>
         </map>
-       <key>TeleportOfferMessageResponse</key>
+       <key>APTeleportOfferMessageResponse</key>
         <map>
             <key>Comment</key>
             <string>Override the default teleport offer message</string>

--- a/indra/newview/app_settings/settings_per_account.xml
+++ b/indra/newview/app_settings/settings_per_account.xml
@@ -2247,5 +2247,71 @@
         <key>Value</key>
             <array/>
         </map>
+        <key>AddFriendReponseChanged</key>
+        <map>
+        <key>Comment</key>
+            <string>Does the Add Friend message differ from the default?</string>
+        <key>Persist</key>
+            <integer>1</integer>
+        <key>Type</key>
+            <string>Boolean</string>
+        <key>Value</key>
+            <integer>0</integer>
+        </map>
+        <key>AddFriendMessageResponse</key>
+        <map>
+            <key>Comment</key>
+            <string>Override the default add friend message</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>String</string>
+            <key>Value</key>
+            <string/>
+        </map>
+        <key>TeleportRequestResponseChanged</key>
+        <map>
+        <key>Comment</key>
+            <string>Does the Teleport Request message differ from the default?</string>
+        <key>Persist</key>
+            <integer>1</integer>
+        <key>Type</key>
+            <string>Boolean</string>
+        <key>Value</key>
+            <integer>0</integer>
+        </map>
+        <key>TeleportRequestMessageResponse</key>
+        <map>
+            <key>Comment</key>
+            <string>Override the default teleport offer message</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>String</string>
+            <key>Value</key>
+            <string/>
+        </map>
+        <key>TeleportOfferResponseChanged</key>
+        <map>
+        <key>Comment</key>
+            <string>Does the Teleport offer message differ from the default?</string>
+        <key>Persist</key>
+            <integer>1</integer>
+        <key>Type</key>
+            <string>Boolean</string>
+        <key>Value</key>
+            <integer>0</integer>
+        </map>
+       <key>TeleportOfferMessageResponse</key>
+        <map>
+            <key>Comment</key>
+            <string>Override the default teleport offer message</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>String</string>
+            <key>Value</key>
+            <string/>
+        </map>
     </map>
 </llsd>

--- a/indra/newview/llavataractions.cpp
+++ b/indra/newview/llavataractions.cpp
@@ -163,7 +163,7 @@ void LLAvatarActions::requestFriendshipDialog(const LLUUID& id, const std::strin
     args["NAME"] = LLSLURL("agent", id, "completename").getSLURLString();
     // <AP:PCD>
     // Add the ability to override the default "add friend" message, using preferences
-    args["OVERRIDE_ADD_FRIEND_MESSAGE"] = gSavedPerAccountSettings.getString("AddFriendMessageResponse");
+    args["OVERRIDE_ADD_FRIEND_MESSAGE"] = gSavedPerAccountSettings.getString("APAddFriendMessageResponse");
     // <AP:PCD>
     LLSD payload;
     payload["id"] = id;
@@ -737,7 +737,7 @@ void LLAvatarActions::teleportRequest(const LLUUID& id)
     LLSD payload;
     // <AP:PCD>
     // Override the default request teleport message.
-    notification["OVERRIDE_TELEPORT_REQUEST_MESSAGE"] = gSavedPerAccountSettings.getString("TeleportRequestMessageResponse");
+    notification["OVERRIDE_TELEPORT_REQUEST_MESSAGE"] = gSavedPerAccountSettings.getString("APTeleportRequestMessageResponse");
     // <AP:PCD>
     LLNotificationsUtil::add("TeleportRequestPrompt", notification, payload, teleport_request_callback);
 }

--- a/indra/newview/llavataractions.cpp
+++ b/indra/newview/llavataractions.cpp
@@ -161,6 +161,10 @@ void LLAvatarActions::requestFriendshipDialog(const LLUUID& id, const std::strin
 
     LLSD args;
     args["NAME"] = LLSLURL("agent", id, "completename").getSLURLString();
+    // <AP:PCD>
+    // Add the ability to override the default "add friend" message, using preferences
+    args["OVERRIDE_ADD_FRIEND_MESSAGE"] = gSavedPerAccountSettings.getString("AddFriendMessageResponse");
+    // <AP:PCD>
     LLSD payload;
     payload["id"] = id;
     payload["name"] = name;
@@ -731,7 +735,10 @@ void LLAvatarActions::teleportRequest(const LLUUID& id)
 //  notification["NAME"] = av_name.getCompleteName();
 
     LLSD payload;
-
+    // <AP:PCD>
+    // Override the default request teleport message.
+    notification["OVERRIDE_TELEPORT_REQUEST_MESSAGE"] = gSavedPerAccountSettings.getString("TeleportRequestMessageResponse");
+    // <AP:PCD>
     LLNotificationsUtil::add("TeleportRequestPrompt", notification, payload, teleport_request_callback);
 }
 

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -946,6 +946,28 @@ void LLFloaterPreference::onDoNotDisturbResponseChanged()
     // </FS:Ansariel>
 }
 
+// <AP:PCD> New overrides.
+void LLFloaterPreference::onOverrideAddFriendResponseChanged()
+{
+    bool response_changed_flag =
+        LLTrans::getString("AddFriendResponseDefault") != getChild<LLUICtrl>("add_friend_message")->getValue().asString();
+    gSavedPerAccountSettings.setBOOL("APAddFriendReponseChanged", response_changed_flag);
+}
+
+void LLFloaterPreference::onOverrideTeleportOfferResponseChanged()
+{
+    bool response_changed_flag =
+        LLTrans::getString("TeleportRequestResponseDefault") != getChild<LLUICtrl>("teleport_request_message")->getValue().asString();
+    gSavedPerAccountSettings.setBOOL("APTeleportRequestResponseChanged", response_changed_flag);
+}
+void LLFloaterPreference::onOverrideTeleportRequestResponseChanged()
+{
+    bool response_changed_flag =
+        LLTrans::getString("TeleportOfferResponseDefault") != getChild<LLUICtrl>("teleport_offer_message")->getValue().asString();
+    gSavedPerAccountSettings.setBOOL("APTeleportOfferResponseChanged", response_changed_flag);
+}
+// </AP:PCD>
+
 LLFloaterPreference::~LLFloaterPreference()
 {
     LLConversationLog::instance().removeObserver(this);
@@ -1145,6 +1167,12 @@ void LLFloaterPreference::onOpen(const LLSD& key)
         gSavedPerAccountSettings.getControl("FSMutedAvatarResponse")->getSignal()->connect(boost::bind(&LLFloaterPreference::onDoNotDisturbResponseChanged, this));
         gSavedPerAccountSettings.getControl("FSAwayAvatarResponse")->getSignal()->connect(boost::bind(&LLFloaterPreference::onDoNotDisturbResponseChanged, this));
         // </FS:Ansariel>
+
+        //<AP:PCD> - Temporary fix as it's not working in it's own class.
+        gSavedPerAccountSettings.getControl("APAddFriendMessageResponse")->getSignal()->connect(boost::bind(&LLFloaterPreference::onOverrideAddFriendResponseChanged, this));
+        gSavedPerAccountSettings.getControl("APTeleportOfferMessageResponse")->getSignal()->connect(boost::bind(&LLFloaterPreference::onOverrideTeleportOfferResponseChanged, this));
+        gSavedPerAccountSettings.getControl("APTeleportRequestMessageResponse")->getSignal()->connect(boost::bind(&LLFloaterPreference::onOverrideTeleportRequestResponseChanged, this));
+        // <AP:PCD>
 
         // <FS:Ansariel> FIRE-17630: Properly disable per-account settings backup list
         getChildView("restore_per_account_disable_cover")->setVisible(false);
@@ -3914,9 +3942,6 @@ private:
 
 static LLPanelInjector<LLPanelPreferenceGraphics> t_pref_graph("panel_preference_graphics");
 static LLPanelInjector<LLPanelPreferencePrivacy> t_pref_privacy("panel_preference_privacy");
-// <AP:PCD> - Panel for overrides
-static LLPanelInjector<LLPanelPreferenceOverrides> t_pref_overrides("panel_preference_overrides");
-// </AP:PCD>
 
 bool LLPanelPreferenceGraphics::postBuild()
 {
@@ -6421,56 +6446,3 @@ void FSPanelPreferenceSounds::onOutputDeviceListChanged(LLAudioEngine::output_de
     mOutputDeviceComboBox->setSelectedByValue(selected_device, true);
 }
 // </FS:Ansariel>
-
-// <AP:PCD> - Panel Overrides here
-void LLPanelPreferenceOverrides::onOpen(const LLSD& key)
-{
-     gSavedPerAccountSettings.getControl("APAddFriendMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideAddFriendResponseChanged, this));
-     gSavedPerAccountSettings.getControl("APTeleportOfferMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideTeleportOfferResponseChanged, this));
-     gSavedPerAccountSettings.getControl("APTeleportRequestMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideTeleportRequestResponseChanged, this));
-}
-
-bool LLPanelPreferenceOverrides::postBuild()
-{
-    gSavedPerAccountSettings.setString("APAddFriendMessageResponse", LLTrans::getString("AddFriendResponseDefault"));
-    gSavedPerAccountSettings.setString("APTeleportOfferMessageResponse", LLTrans::getString("TeleportOfferResponseDefault"));
-    gSavedPerAccountSettings.setString("APTeleportRequestMessageResponse", LLTrans::getString("TeleportRequestResponseDefault"));
-    
-    return LLPanelPreference::postBuild();
-}
-
-void LLPanelPreferenceOverrides::draw()
-{
-    LLPanelPreference::draw();
-}
-
-void LLPanelPreferenceOverrides::onOverrideAddFriendResponseChanged() {
-    bool response_changed_flag =
-            LLTrans::getString("AddFriendResponseDefault")
-                    != getChild<LLUICtrl>("add_friend_message")->getValue().asString();
-    gSavedPerAccountSettings.setBOOL("APAddFriendReponseChanged", response_changed_flag );
-}
-
-void LLPanelPreferenceOverrides::onOverrideTeleportRequestResponseChanged() {
-      bool response_changed_flag =
-            LLTrans::getString("TeleportRequestResponseDefault")
-                    != getChild<LLUICtrl>("teleport_request_message")->getValue().asString();
-     gSavedPerAccountSettings.setBOOL("APTeleportRequestResponseChanged", response_changed_flag );
-}
-
-void LLPanelPreferenceOverrides::onOverrideTeleportOfferResponseChanged() {
-      bool response_changed_flag =
-            LLTrans::getString("TeleportOfferResponseDefault")
-                    != getChild<LLUICtrl>("teleport_offer_message")->getValue().asString();
-     gSavedPerAccountSettings.setBOOL("APTeleportOfferResponseChanged", response_changed_flag );
-}
-
-void LLPanelPreferenceOverrides::cancel(const std::vector<std::string> settings_to_skip)
-{
-    LLPanelPreference::cancel(settings_to_skip);
-}
-void LLPanelPreferenceOverrides::saveSettings()
-{
-    LLPanelPreference::saveSettings();
-}
-// </AP:PCD>

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -954,13 +954,13 @@ void LLFloaterPreference::onOverrideAddFriendResponseChanged()
     gSavedPerAccountSettings.setBOOL("APAddFriendReponseChanged", response_changed_flag);
 }
 
-void LLFloaterPreference::onOverrideTeleportOfferResponseChanged()
+void LLFloaterPreference::onOverrideTeleportRequestResponseChanged()
 {
     bool response_changed_flag =
         LLTrans::getString("TeleportRequestResponseDefault") != getChild<LLUICtrl>("teleport_request_message")->getValue().asString();
     gSavedPerAccountSettings.setBOOL("APTeleportRequestResponseChanged", response_changed_flag);
 }
-void LLFloaterPreference::onOverrideTeleportRequestResponseChanged()
+void LLFloaterPreference::onOverrideTeleportOfferResponseChanged()
 {
     bool response_changed_flag =
         LLTrans::getString("TeleportOfferResponseDefault") != getChild<LLUICtrl>("teleport_offer_message")->getValue().asString();

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -723,8 +723,8 @@ bool LLFloaterPreference::postBuild()
 
         // <AP:PCD> - Override defaults
         gSavedPerAccountSettings.setString("APAddFriendMessageReponse", LLTrans::getString("AddFriendResponseDefault"));
-        gSavedPerAccountSettings.setString("APTeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
-        gSavedPerAccountSettings.setString("APTeleportOfferResponse", LLTrans::getString("TeleportOfferResponseDefault"));
+        gSavedPerAccountSettings.setString("APTeleportRequestMessageResponse", LLTrans::getString("TeleportRequestResponseDefault"));
+        gSavedPerAccountSettings.setString("APTeleportOfferMessageResponse", LLTrans::getString("TeleportOfferResponseDefault"));
         //<AP:PCD>
     }
 
@@ -1420,7 +1420,7 @@ void LLFloaterPreference::initDoNotDisturbResponse()
 
         if (!gSavedPerAccountSettings.getBOOL("APTeleportRequestResponseChanged"))
         {
-            gSavedPerAccountSettings.setString("APTeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
+            gSavedPerAccountSettings.setString("APTeleportRequestMessageResponse", LLTrans::getString("TeleportRequestResponseDefault"));
         }
         // </AP:PCD>
     }
@@ -6432,13 +6432,10 @@ void LLPanelPreferenceOverrides::onOpen(const LLSD& key)
 
 bool LLPanelPreferenceOverrides::postBuild()
 {
-     if (LLStartUp::getStartupState() < STATE_STARTED)
-    {
-        gSavedPerAccountSettings.setString("APAddFriendMessageResponse", LLTrans::getString("AddFriendResponseDefault"));
-        gSavedPerAccountSettings.setString("APTeleportOfferMessageResponse", LLTrans::getString("TeleportOfferResponseDefault"));
-        gSavedPerAccountSettings.setString("APTeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
-    }
-
+    gSavedPerAccountSettings.setString("APAddFriendMessageResponse", LLTrans::getString("AddFriendResponseDefault"));
+    gSavedPerAccountSettings.setString("APTeleportOfferMessageResponse", LLTrans::getString("TeleportOfferResponseDefault"));
+    gSavedPerAccountSettings.setString("APTeleportRequestMessageResponse", LLTrans::getString("TeleportRequestResponseDefault"));
+    
     return LLPanelPreference::postBuild();
 }
 

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -722,9 +722,9 @@ bool LLFloaterPreference::postBuild()
         // </FS:Ansariel>
 
         // <AP:PCD> - Override defaults
-        gSavedPerAccountSettings.setString("AddFriendReponse", LLTrans::getString("AddFriendResponseDefault"));
-        gSavedPerAccountSettings.setString("TeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
-        gSavedPerAccountSettings.setString("TeleportOfferResponse", LLTrans::getString("TeleportOfferResponseDefault"));
+        gSavedPerAccountSettings.setString("APAddFriendMessageReponse", LLTrans::getString("AddFriendResponseDefault"));
+        gSavedPerAccountSettings.setString("APTeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
+        gSavedPerAccountSettings.setString("APTeleportOfferResponse", LLTrans::getString("TeleportOfferResponseDefault"));
         //<AP:PCD>
     }
 
@@ -1405,6 +1405,24 @@ void LLFloaterPreference::initDoNotDisturbResponse()
             gSavedPerAccountSettings.setString("FSAwayAvatarResponse", LLTrans::getString("AwayAvatarResponseDefault"));
         }
         // </FS:Ansariel>
+
+        // <AP:PCD> Initialize the overrides
+        
+        if (!gSavedPerAccountSettings.getBOOL("APAddFriendReponseChanged"))
+        {
+            gSavedPerAccountSettings.setString("APAddFriendMessageResponse", LLTrans::getString("AddFriendResponseDefault"));
+        }
+
+        if (!gSavedPerAccountSettings.getBOOL("APTeleportOfferResponseChanged"))
+        {
+            gSavedPerAccountSettings.setString("APTeleportOfferMessageResponse", LLTrans::getString("TeleportOfferResponseDefault"));
+        }
+
+        if (!gSavedPerAccountSettings.getBOOL("APTeleportRequestResponseChanged"))
+        {
+            gSavedPerAccountSettings.setString("APTeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
+        }
+        // </AP:PCD>
     }
 
 //static
@@ -6418,7 +6436,7 @@ bool LLPanelPreferenceOverrides::postBuild()
     {
         gSavedPerAccountSettings.setString("APAddFriendMessageResponse", LLTrans::getString("AddFriendResponseDefault"));
         gSavedPerAccountSettings.setString("APTeleportOfferMessageResponse", LLTrans::getString("TeleportOfferResponseDefault"));
-        gSavedPerAccountSettings.setString("TeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
+        gSavedPerAccountSettings.setString("APTeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
     }
 
     return LLPanelPreference::postBuild();

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -6407,17 +6407,17 @@ void FSPanelPreferenceSounds::onOutputDeviceListChanged(LLAudioEngine::output_de
 // <AP:PCD> - Panel Overrides here
 void LLPanelPreferenceOverrides::onOpen(const LLSD& key)
 {
-     gSavedPerAccountSettings.getControl("AddFriendMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideAddFriendResponseChanged, this));
-     gSavedPerAccountSettings.getControl("TeleportOfferMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideTeleportOfferResponseChanged, this));
-     gSavedPerAccountSettings.getControl("TeleportRequestMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideTeleportRequestResponseChanged, this));
+     gSavedPerAccountSettings.getControl("APAddFriendMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideAddFriendResponseChanged, this));
+     gSavedPerAccountSettings.getControl("APTeleportOfferMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideTeleportOfferResponseChanged, this));
+     gSavedPerAccountSettings.getControl("APTeleportRequestMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideTeleportRequestResponseChanged, this));
 }
 
 bool LLPanelPreferenceOverrides::postBuild()
 {
      if (LLStartUp::getStartupState() < STATE_STARTED)
     {
-        gSavedPerAccountSettings.setString("AddFriendMessageResponse", LLTrans::getString("AddFriendResponseDefault"));
-        gSavedPerAccountSettings.setString("TeleportOfferMessageResponse", LLTrans::getString("TeleportOfferResponseDefault"));
+        gSavedPerAccountSettings.setString("APAddFriendMessageResponse", LLTrans::getString("AddFriendResponseDefault"));
+        gSavedPerAccountSettings.setString("APTeleportOfferMessageResponse", LLTrans::getString("TeleportOfferResponseDefault"));
         gSavedPerAccountSettings.setString("TeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
     }
 
@@ -6433,21 +6433,21 @@ void LLPanelPreferenceOverrides::onOverrideAddFriendResponseChanged() {
     bool response_changed_flag =
             LLTrans::getString("AddFriendResponseDefault")
                     != getChild<LLUICtrl>("add_friend_message")->getValue().asString();
-    gSavedPerAccountSettings.setBOOL("AddFriendReponseChanged", response_changed_flag );
+    gSavedPerAccountSettings.setBOOL("APAddFriendReponseChanged", response_changed_flag );
 }
 
 void LLPanelPreferenceOverrides::onOverrideTeleportRequestResponseChanged() {
       bool response_changed_flag =
             LLTrans::getString("TeleportRequestResponseDefault")
                     != getChild<LLUICtrl>("teleport_request_message")->getValue().asString();
-     gSavedPerAccountSettings.setBOOL("TeleportRequestResponseChanged", response_changed_flag );
+     gSavedPerAccountSettings.setBOOL("APTeleportRequestResponseChanged", response_changed_flag );
 }
 
 void LLPanelPreferenceOverrides::onOverrideTeleportOfferResponseChanged() {
       bool response_changed_flag =
             LLTrans::getString("TeleportOfferResponseDefault")
                     != getChild<LLUICtrl>("teleport_offer_message")->getValue().asString();
-     gSavedPerAccountSettings.setBOOL("TeleportOfferResponseChanged", response_changed_flag );
+     gSavedPerAccountSettings.setBOOL("APTeleportOfferResponseChanged", response_changed_flag );
 }
 
 void LLPanelPreferenceOverrides::cancel(const std::vector<std::string> settings_to_skip)

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -720,6 +720,12 @@ bool LLFloaterPreference::postBuild()
         gSavedPerAccountSettings.setString("FSMutedAvatarResponse", LLTrans::getString("MutedAvatarsResponseDefault"));
         gSavedPerAccountSettings.setString("FSAwayAvatarResponse", LLTrans::getString("AwayAvatarResponseDefault"));
         // </FS:Ansariel>
+
+        // <AP:PCD> - Override defaults
+        gSavedPerAccountSettings.setString("AddFriendReponse", LLTrans::getString("AddFriendResponseDefault"));
+        gSavedPerAccountSettings.setString("TeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
+        gSavedPerAccountSettings.setString("TeleportOfferResponse", LLTrans::getString("TeleportOfferResponseDefault"));
+        //<AP:PCD>
     }
 
     // set 'enable' property for 'Clear log...' button
@@ -3890,6 +3896,9 @@ private:
 
 static LLPanelInjector<LLPanelPreferenceGraphics> t_pref_graph("panel_preference_graphics");
 static LLPanelInjector<LLPanelPreferencePrivacy> t_pref_privacy("panel_preference_privacy");
+// <AP:PCD> - Panel for overrides
+static LLPanelInjector<LLPanelPreferenceOverrides> t_pref_overrides("panel_preference_overrides");
+// </AP:PCD>
 
 bool LLPanelPreferenceGraphics::postBuild()
 {
@@ -6394,3 +6403,59 @@ void FSPanelPreferenceSounds::onOutputDeviceListChanged(LLAudioEngine::output_de
     mOutputDeviceComboBox->setSelectedByValue(selected_device, true);
 }
 // </FS:Ansariel>
+
+// <AP:PCD> - Panel Overrides here
+void LLPanelPreferenceOverrides::onOpen(const LLSD& key)
+{
+     gSavedPerAccountSettings.getControl("AddFriendMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideAddFriendResponseChanged, this));
+     gSavedPerAccountSettings.getControl("TeleportOfferMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideTeleportOfferResponseChanged, this));
+     gSavedPerAccountSettings.getControl("TeleportRequestMessageResponse")->getSignal()->connect(boost::bind(&LLPanelPreferenceOverrides::onOverrideTeleportRequestResponseChanged, this));
+}
+
+bool LLPanelPreferenceOverrides::postBuild()
+{
+     if (LLStartUp::getStartupState() < STATE_STARTED)
+    {
+        gSavedPerAccountSettings.setString("AddFriendMessageResponse", LLTrans::getString("AddFriendResponseDefault"));
+        gSavedPerAccountSettings.setString("TeleportOfferMessageResponse", LLTrans::getString("TeleportOfferResponseDefault"));
+        gSavedPerAccountSettings.setString("TeleportRequestResponse", LLTrans::getString("TeleportRequestResponseDefault"));
+    }
+
+    return LLPanelPreference::postBuild();
+}
+
+void LLPanelPreferenceOverrides::draw()
+{
+    LLPanelPreference::draw();
+}
+
+void LLPanelPreferenceOverrides::onOverrideAddFriendResponseChanged() {
+    bool response_changed_flag =
+            LLTrans::getString("AddFriendResponseDefault")
+                    != getChild<LLUICtrl>("add_friend_message")->getValue().asString();
+    gSavedPerAccountSettings.setBOOL("AddFriendReponseChanged", response_changed_flag );
+}
+
+void LLPanelPreferenceOverrides::onOverrideTeleportRequestResponseChanged() {
+      bool response_changed_flag =
+            LLTrans::getString("TeleportRequestResponseDefault")
+                    != getChild<LLUICtrl>("teleport_request_message")->getValue().asString();
+     gSavedPerAccountSettings.setBOOL("TeleportRequestResponseChanged", response_changed_flag );
+}
+
+void LLPanelPreferenceOverrides::onOverrideTeleportOfferResponseChanged() {
+      bool response_changed_flag =
+            LLTrans::getString("TeleportOfferResponseDefault")
+                    != getChild<LLUICtrl>("teleport_offer_message")->getValue().asString();
+     gSavedPerAccountSettings.setBOOL("TeleportOfferResponseChanged", response_changed_flag );
+}
+
+void LLPanelPreferenceOverrides::cancel(const std::vector<std::string> settings_to_skip)
+{
+    LLPanelPreference::cancel(settings_to_skip);
+}
+void LLPanelPreferenceOverrides::saveSettings()
+{
+    LLPanelPreference::saveSettings();
+}
+// </AP:PCD>

--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -177,6 +177,12 @@ protected:
     // <FS:Zi> Group Notices and chiclets location setting conversion bool => S32
     void onShowGroupNoticesTopRightChanged();
 
+    // <AP:PCD> ditched the panel cause signals suck.
+    void onOverrideAddFriendResponseChanged();
+    void onOverrideTeleportOfferResponseChanged();
+    void onOverrideTeleportRequestResponseChanged();
+    //</AP:PCD>
+
 public:
     // This function squirrels away the current values of the controls so that
     // cancel() can restore them.
@@ -678,23 +684,4 @@ private:
     control_values_map_t mSavedValues;
     LOG_CLASS(LLFloaterPreferenceProxy);
 };
-
-// <AP:PCD> -- New Panel for overrides
-class LLPanelPreferenceOverrides : public LLPanelPreference
-{
-public:
-    bool postBuild();
-    void onOpen(const LLSD& key);
-    void draw();
-    void cancel(const std::vector<std::string> settings_to_skip = {});
-    void saveSettings();
-protected:
-    void onOverrideAddFriendResponseChanged();
-    void onOverrideTeleportRequestResponseChanged();
-    void onOverrideTeleportOfferResponseChanged();
-
-private:
-    LOG_CLASS(LLPanelPreferenceOverrides);
-};
-// </AP:PCD>
 #endif  // LL_LLPREFERENCEFLOATER_H

--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -679,5 +679,22 @@ private:
     LOG_CLASS(LLFloaterPreferenceProxy);
 };
 
+// <AP:PCD> -- New Panel for overrides
+class LLPanelPreferenceOverrides : public LLPanelPreference
+{
+public:
+    bool postBuild();
+    void onOpen(const LLSD& key);
+    void draw();
+    void cancel(const std::vector<std::string> settings_to_skip = {});
+    void saveSettings();
+protected:
+    void onOverrideAddFriendResponseChanged();
+    void onOverrideTeleportRequestResponseChanged();
+    void onOverrideTeleportOfferResponseChanged();
 
+private:
+    LOG_CLASS(LLPanelPreferenceOverrides);
+};
+// </AP:PCD>
 #endif  // LL_LLPREFERENCEFLOATER_H

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -7915,6 +7915,9 @@ void handle_lure(const uuid_vec_t& ids)
     LLSD edit_args;
 // [RLVa:KB] - Checked: 2010-04-07 (RLVa-1.2.0d) | Modified: RLVa-1.0.0a
     edit_args["REGION"] = (!gRlvHandler.hasBehaviour(RLV_BHVR_SHOWLOC)) ? gAgent.getRegion()->getName() : RlvStrings::getString(RlvStringKeys::Hidden::Generic);
+    // <AP:PCD> - Override TP offer
+    edit_args["OVERRIDE_TELEPORT_OFFER_MESSAGE"] = gSavedPerAccountSettings.getString("TeleportOfferMessageResponse");
+    // </AP:PCD>
 // [/RLVa:KB]
 //  edit_args["REGION"] = gAgent.getRegion()->getName();
 

--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -7916,7 +7916,7 @@ void handle_lure(const uuid_vec_t& ids)
 // [RLVa:KB] - Checked: 2010-04-07 (RLVa-1.2.0d) | Modified: RLVa-1.0.0a
     edit_args["REGION"] = (!gRlvHandler.hasBehaviour(RLV_BHVR_SHOWLOC)) ? gAgent.getRegion()->getName() : RlvStrings::getString(RlvStringKeys::Hidden::Generic);
     // <AP:PCD> - Override TP offer
-    edit_args["OVERRIDE_TELEPORT_OFFER_MESSAGE"] = gSavedPerAccountSettings.getString("TeleportOfferMessageResponse");
+    edit_args["OVERRIDE_TELEPORT_OFFER_MESSAGE"] = gSavedPerAccountSettings.getString("APTeleportOfferMessageResponse");
     // </AP:PCD>
 // [/RLVa:KB]
 //  edit_args["REGION"] = gAgent.getRegion()->getName();

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -3243,7 +3243,7 @@ Offer friendship to [NAME]?
     <tag>confirm</tag>
     <form name="form">
       <input name="message" type="text" default="true">
-Would you be my friend?
+[OVERRIDE_ADD_FRIEND_MESSAGE]
       </input>
       <button
        default="true"
@@ -5141,7 +5141,7 @@ Offer a teleport to your location with the following message?
     <tag>confirm</tag>
     <form name="form">
       <input name="message" type="text" default="true">
-Join me in [REGION]
+      [OVERRIDE_TELEPORT_OFFER_MESSAGE]
       </input>
 			<button
        default="true"
@@ -5163,7 +5163,7 @@ Request a teleport to [NAME] with the following message
     <tag>confirm</tag>
     <form name="form">
       <input name="message" type="text">
-
+         [OVERRIDE_TELEPORT_REQUEST_MESSAGE]
       </input>
       <button
        default="true"
@@ -5197,7 +5197,7 @@ God summon this resident to your location?
     <tag>confirm</tag>
     <form name="form">
       <input name="message" type="text" default="true">
-Join me in [REGION]
+      [OVERRIDE_TELEPORT_OFFER_MESSAGE]
       </input>
       <button
        default="true"

--- a/indra/newview/skins/default/xui/en/panel_preferences_override.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_override.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<panel
+    height="408"
+    layout="topleft"
+    name="override_defaults"
+    top="0"
+    left="13"
+    width="525"> <text
+     type="string"
+     length="1"
+     follows="left|top"
+     height="13"
+     layout="topleft"
+     left="30"
+     mouse_opaque="false"
+     name="text_box1"
+     top_pad="3"
+     width="240">
+      Override Add Friend Message
+     </text>
+    <text_editor
+     control_name="AddFriendMessageResponse"
+      text_readonly_color="LabelDisabledColor"
+      bg_writeable_color="LtGray"
+      use_ellipses="false"
+     commit_on_focus_lost = "true"
+     follows="left|top"
+     height="29"
+     layout="topleft"
+     left="30"
+     name="add_friend_message"
+     width="470"
+     word_wrap="true">
+       log_in_to_change
+    </text_editor>
+    <text
+     type="string"
+     length="1"
+     follows="left|top"
+     height="13"
+     layout="topleft"
+     left="30"
+     mouse_opaque="false"
+     name="text_box2"
+     top_pad="3"
+     width="240">
+     Override default Teleport Offer message
+     </text>
+    <text_editor
+     control_name="TeleportOfferMessageResponse"
+      text_readonly_color="LabelDisabledColor"
+      bg_writeable_color="LtGray"
+      use_ellipses="false"
+     commit_on_focus_lost = "true"
+     follows="left|top"
+     height="29"
+     layout="topleft"
+     left="30"
+     name="teleport_offer_message"
+     width="470"
+     word_wrap="true">
+       log_in_to_change
+    </text_editor>
+    <text
+     type="string"
+     length="1"
+     follows="left|top"
+     height="13"
+     layout="topleft"
+     left="30"
+     mouse_opaque="false"
+     name="text_box3"
+     top_pad="3"
+     width="240">
+     Override the default Teleport Request message
+     </text>
+    <text_editor
+     control_name="TeleportRequestMessageResponse"
+      text_readonly_color="LabelDisabledColor"
+      bg_writeable_color="LtGray"
+      use_ellipses="false"
+     commit_on_focus_lost = "true"
+     follows="left|top"
+     height="29"
+     layout="topleft"
+     left="30"
+     name="teleport_request_message"
+     width="470"
+     word_wrap="true">
+       log_in_to_change
+    </text_editor>
+</panel>

--- a/indra/newview/skins/default/xui/en/panel_preferences_override.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_override.xml
@@ -19,7 +19,7 @@
       Override Add Friend Message
      </text>
     <text_editor
-     control_name="AddFriendMessageResponse"
+     control_name="APAddFriendMessageResponse"
       text_readonly_color="LabelDisabledColor"
       bg_writeable_color="LtGray"
       use_ellipses="false"
@@ -47,7 +47,7 @@
      Override default Teleport Offer message
      </text>
     <text_editor
-     control_name="TeleportOfferMessageResponse"
+     control_name="APTeleportOfferMessageResponse"
       text_readonly_color="LabelDisabledColor"
       bg_writeable_color="LtGray"
       use_ellipses="false"
@@ -75,7 +75,7 @@
      Override the default Teleport Request message
      </text>
     <text_editor
-     control_name="TeleportRequestMessageResponse"
+     control_name="APTeleportRequestMessageResponse"
       text_readonly_color="LabelDisabledColor"
       bg_writeable_color="LtGray"
       use_ellipses="false"

--- a/indra/newview/skins/default/xui/en/panel_preferences_override.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_override.xml
@@ -71,7 +71,7 @@
      mouse_opaque="false"
      name="text_box3"
      top_pad="3"
-     width="240">
+     width="270/">
      Override the default Teleport Request message
      </text>
     <text_editor

--- a/indra/newview/skins/default/xui/en/panel_preferences_privacy.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_privacy.xml
@@ -776,5 +776,13 @@
          width="40"/>
 
     </panel>
+    <panel top_pad="5"
+     bottom="-1"
+     left="1"
+     right="-1"
+     follows="all"
+     label="Overrides"
+     name="tab-override-defaults"
+     filename="paneL_preferences_override.xml" />
 </tab_container>
 </panel>

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -1314,6 +1314,11 @@ If you continue to receive this message, please contact Second Life support for 
   <string name="MutedAvatarsResponseDefault">The Resident you messaged has blocked you from sending them any messages.</string>
   <string name="AwayAvatarResponseDefault">The Resident you messaged is currently away from keyboard. Your message will still be shown in their IM panel for later viewing.</string>
 
+  <!-- panel preferences overrides -->
+  <string name="AddFriendResponseDefault">Would you be my friend?</string>
+  <string name="TeleportOfferResponseDefault">Care to join me?</string>
+  <string name="TeleportRequestResponseDefault">May I join you?</string>
+
 	<!-- Mute -->
 	<string name="MuteByName">(By name)</string>
 	<string name="MuteAgent">(Resident)</string>


### PR DESCRIPTION
This PR addresses enhancement / feature request of Issue https://github.com/ApertureViewer/Aperture-Viewer/issues/23 by allowing users to override default messages.


Addresses: https://github.com/ApertureViewer/Aperture-Viewer/issues/23

### Changelog

### Files changed

- `indra/newview/app_settings/settings_per_account.xml` - for the new override settings per user / account
- `indra/newview/skins/default/xui/en/notifications.xml` - notification dialogs 
- `indra/newview/skins/default/xui/en/strings.xml` - adding the default overrides.
- `indra/newview/skins/default/xui/en/panel_preferences_privacy.xml` - adds new panel/tab to privacy called **Overrides**
- `indra/newview/llavataractions.cpp` - overriding the actual messages in the string table / settings
- `indra/newview/llfloaterpreference.cpp` - added 3 new "changed" signals. `onOverrideAddFriendResponseChanged`, `onOverrideTeleportOfferResponseChanged` and `onOverrideTeleportRequestResponseChanged`
- `indra/newview/llfloaterpreference.h` - added the definitions for the  3 new "changed" signals. `onOverrideAddFriendResponseChanged`, `onOverrideTeleportOfferResponseChanged` and `onOverrideTeleportRequestResponseChanged`
- `indra/newview/llviewermessage.cpp` - overides the teleport offer message*

### New files 
- `indra/newview/skins/default/xui/en/panel_preferences_override.xml` - this is the new override panel


### *Known Issues / Caveats

Previously the `[REGION]` was translated to the current region. That does not happen if you change that as it's doing a string translation and I'm not sure if you can string translate of a string translation.... that would have to be tested...