### PR TITLE
[FEAT] Panel Preference Rebrand

### DIFF
--- a/indra/newview/fspanelprefs.cpp
+++ b/indra/newview/fspanelprefs.cpp
@@ -41,7 +41,7 @@
 #include "lltexturectrl.h"
 #include "llviewercontrol.h"
 
-static LLPanelInjector<FSPanelPrefs> t_pref_fs("panel_preference_firestorm");
+static LLPanelInjector<FSPanelPrefs> t_pref_fs("panel_preference_aperture");
 
 FSPanelPrefs::FSPanelPrefs() : LLPanelPreference()
 {

--- a/indra/newview/skins/default/xui/en/floater_preferences.xml
+++ b/indra/newview/skins/default/xui/en/floater_preferences.xml
@@ -198,12 +198,12 @@
          help_topic="preferences_crashreports_tab"
          name="crashreports" />
         <panel
-         class="panel_preference_firestorm"
-         filename="panel_preferences_firestorm.xml"
-         label="Firestorm"
+         class="panel_preference_aperture"
+         filename="panel_preferences_aperture.xml"
+         label="Aperture"
          layout="topleft"
          help_topic="preferences_firestorm_tab"
-         name="firestorm" />
+         name="aperture" />
         <panel
          class="panel_preference_opensim"
          filename="panel_preferences_opensim.xml"

--- a/indra/newview/skins/default/xui/en/panel_preferences_aperture.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_aperture.xml
@@ -1,0 +1,1837 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<panel
+ border="true"
+ follows="all"
+ height="440"
+ layout="topleft"
+ left="1"
+ top="1"
+ width="540"
+ label="Aperture"
+ name="aperture">
+ 
+<panel.string name="BeamsOffLabel">
+	=== OFF ===
+</panel.string>
+	<string name="EmbeddedItemNotSet">
+		Not set
+	</string>
+	<string name="EmbeddedItemNotAvailable">
+		Not available
+	</string>
+	<string name="EmbeddedItemNotLoggedIn">
+		Not logged in
+	</string>
+
+<tab_container
+ label="Aperture Prefs"
+ layout="topleft"
+ follows="all"
+ top="5"
+ bottom="-1"
+ left="1"
+ right="-1"
+ name="tabs"
+ tab_min_width="50"
+ tab_position="top" >
+
+    <!--Extras-->
+    <panel
+     top_pad="5"
+     bottom="-1"
+     left="1"
+     right="-1"
+     follows="all"
+     label="Extras"
+     name="tab-extras" >
+        <check_box
+         control_name="RestrainedLove"
+         layout="topleft"
+         follows="left|top"
+         top_pad="6"
+         left="10"
+         width="270"
+         height="20"
+         name="checkMiscRLVa"
+         label="Allow Remote Scripted Viewer Controls  (RLVa)"/>
+        <text
+         layout="topleft"
+         follows="left|top"
+         left_pad="5"
+         height="16"
+         width="150"
+         name="textMiscRLVaRestart"
+         text_color="White_25">
+            (requires restart)
+        </text>
+        <check_box
+         top_pad="3"
+         left="10"
+         follows="left|top"
+         height="16"
+         label="Always rez objects under the land group if possible"
+         name="grouplandrez"
+         width="270"
+         control_name="RezUnderLandGroup"
+         tool_tip="Attempts to rez objects under the land group if you're in the land group regardless of which current group tag you're wearing."/>
+		<check_box
+		 control_name="EffectScriptChatParticles"
+		 height="16"
+		 label="Create particle effects when scripts communicate"
+		 layout="topleft"
+		 name="EffectScriptChatParticles"
+		 tool_tip="If enabled scripted objects display swirling particle lights when the scripts communicate"
+		 initial_value="true"
+		 top_pad="3"
+		 width="350" />
+        <check_box
+         top_pad="3"
+         follows="left|top"
+         height="16"
+         label="Deactivate tracking beacon when reaching the targeted avatar (&lt;= 3m)"
+         name="FSDisableAvatarTrackerAtCloseIn"
+         width="270"
+         control_name="FSDisableAvatarTrackerAtCloseIn"
+         tool_tip="If enabled, the tracking beacon will be disabled automatically, if the distance to the targeted avatar is less than 3m. (Default)"/>
+        <check_box
+         top_pad="3"
+         follows="left|top"
+         height="16"
+         label="Fix Bento Idle Animation"
+         name="play_default_bento_idle_animation_toggle"
+         tool_tip="If enabled, the viewer will run a default, priority 0 bento animation that poses hands, wings, mouth and tail in a natural position when no other bento animation is running."
+         width="270"
+         control_name="FSPlayDefaultBentoAnimation"/>
+        <check_box
+         top_pad="10"
+         follows="left|top"
+         height="16"
+         label="Disable Login Progress Screen"
+         name="login_screen_toggle"
+         width="270"
+         control_name="FSDisableLoginScreens"
+         tool_tip="Disables the black login progress Screen"/>
+        <check_box
+         top_pad="3"
+         follows="left|top"
+         height="16"
+         label="Disable Logout Progress Screen"
+         name="logout_screen_toggle"
+         width="270"
+         control_name="FSDisableLogoutScreens"
+         tool_tip="Disables the black Logout progress screen."/>
+
+		<check_box
+		 control_name="FSRenderFarClipStepping"
+		 height="16"
+		 label="Enable progressive draw distance stepping"
+		 layout="topleft"
+		 name="FSRenderFarClipStepping"
+		 tool_tip="If enabled, Aperture will use a progressive draw distance stepping after teleporting."
+		 initial_value="true"
+		 top_pad="10"
+		 width="250" />
+		<slider
+		 name="progressive_draw_distance_interval"
+		 control_name="FSRenderFarClipSteppingInterval"
+		 enabled_control="FSRenderFarClipStepping"
+		 decimal_digits="0"
+		 left="10"
+		 top_pad="2"
+		 follows="left|top"
+		 layout="topleft"
+		 height="18"
+		 increment="1"
+		 initial_value="20"
+		 max_val="30"
+		 min_val="5"
+		 width="225"
+		 tool_tip="Interval in seconds between each draw distance increment"/>
+
+        <check_box
+         top_pad="10"
+         control_name="UseLSLBridge"
+         follows="left|top"
+         height="16"
+         initial_value="true"
+         name="UseLSLBridge"
+         label="Enable LSL-Client Bridge"
+         left="10"
+         width="270"
+         tool_tip="Allows the Viewer to use a scripted attachment (Bridge) to extend its features"/>
+        <combo_box
+         control_name="UseLSLFlightAssist"
+         enabled_control="UseLSLBridge"
+         layout="topleft"
+		 left="10"
+		 top_pad="2"
+         follows="left|top"
+         height="25"
+         name="UseLSLFlightAssist"
+         tool_tip="Enables the script that assists flying and hovering at extended altitudes"
+         width="225">
+            <combo_box.item
+             label="Flight Assist: Disabled"
+             name="flight_disabled"
+             value="0.0" />
+            <combo_box.item
+             label="Flight Assist: Mild boost"
+             name="flight_mild"
+             value="0.5" />
+            <combo_box.item
+             label="Flight Assist: Moderate boost"
+             name="flight_moderate"
+             value="1.0" />
+            <combo_box.item
+             label="Flight Assist: Strong boost"
+             name="flight_strong"
+             value="2.0" />
+            <combo_box.item
+             label="Flight Assist: Extreme boost"
+             name="flight_extreme"
+             value="15.0" />
+        </combo_box>
+        <slider
+         name="manual_environment_change_transition_period"
+         control_name="FSEnvironmentManualTransitionTime"
+         label="Environment Transition Time:"
+         decimal_digits="1"
+         left="12"
+         top_pad="15"
+         follows="left|top"
+         layout="topleft"
+         height="18"
+         increment="0.5"
+         initial_value="0"
+         max_val="60"
+         min_val="0"
+         width="520"
+         tool_tip="Interval in seconds over which manual environment changes will blend. Zero is instant."/>
+        <check_box
+         top_pad="5"
+         control_name="EnvironmentPersistAcrossLogin"
+         follows="left|top"
+         height="16"
+         initial_value="true"
+         name="EnvironmentPersistAcrossLogin"
+         label="Persist Environment settings throughout sessions"
+         left="10"
+         width="500"
+         tool_tip="Restores the current environment settings after next login."/>
+    </panel>
+
+
+    <!--Protection-->
+    <panel
+     top_pad="5"
+     bottom="-1"
+     left="1"
+     right="-1"
+     follows="all"
+     label="Protection"
+     name="ProtectionTab">
+        <check_box
+         top_pad="10"
+         left="10"
+         label="Block left-click sitting on objects"
+         control_name="FSBlockClickSit"
+         follows="left|top"
+         height="16"
+         name="FSBlockClickSit"
+         width="256" />
+        <check_box
+         top_pad="4"
+         label="Allow scripts to show map UI (llMapDestination)"
+         control_name="ScriptsCanShowUI"
+         follows="left|top"
+         height="16"
+         name="ScriptsCanShowUI"
+         width="256" />
+
+        <text
+         top_pad="5"
+         follows="left|top"
+         height="12"
+         name="revokepermissions_txt"
+         width="200">
+         Revoke Permissions:
+         </text>
+        <radio_group
+         top_pad="5"
+         left="20"
+         height="62"
+         layout="topleft"
+         control_name="FSRevokePerms"
+         name="FSRevokePerms"
+         tool_tip=""
+         width="331">
+            <radio_item
+             height="16"
+             label="Never (Original behaviour)"
+             layout="topleft"
+             name="never_radio"
+             value="0"
+             top_pad="0"
+             width="150" />
+            <radio_item
+             height="16"
+             label="Revoke on SIT"
+             layout="topleft"
+             top_pad="0"
+             name="sit_radio"
+             value="1"
+             width="150" />
+            <radio_item
+             height="16"
+             label="Revoke on STAND"
+             layout="topleft"
+             top_pad="0"
+             name="stand_radio"
+             value="2"
+             width="150" />
+            <radio_item
+             height="16"
+             label="Revoke on SIT and STAND"
+             layout="topleft"
+             top_pad="0"
+             name="sitnstand_radio"
+             value="3"
+             width="150" />
+        </radio_group>
+
+        <text
+         left="10"
+         top_pad="5"
+         follows="left|top"
+         height="12"
+         name="SurfaceAreaThreshholdLabel"
+         width="360">
+         Texture Lag Protection (may break some objects):
+         </text>
+        <check_box
+         top_pad="8"
+         left="20"
+         label="Automatically hide large objects with high texture area. Threshold: "
+         control_name="RenderVolumeSAProtection"
+         follows="left|top"
+         height="16"
+         name="RenderVolumeSAProtection"
+         width="380"
+         tool_tip="This protects you from objects with very large textures over large surface areas often designed to crash the viewer. Default is 5000 square meters, but if you find that some objects are not rendering and this option is enabled you may need to increase it."/>
+        <spinner
+         enabled_control="RenderVolumeSAProtection"
+         top_delta="-5"
+         control_name="RenderVolumeSAFrameMax"
+         decimal_digits="0"
+         layout="topleft"
+         follows="left|top"
+         height="18"
+         left_pad="5"
+         increment="1"
+         initial_value="5000"
+         max_val="10000"
+         min_val="500"
+         name="RenderVolumeSAFrameMax"
+         width="90" />
+
+        <check_box
+         top_pad="10"
+         left="10"
+         label="Enable Spam Protection"
+         control_name="UseAntiSpam"
+         follows="left|top"
+         height="16"
+         name="UseAntiSpam"
+         width="200" />
+        <!-- FS:TS FIRE-23138: Enable spam protection for user's objects -->
+        <check_box
+         left="20"
+         label="Enable Spam Protection even for objects owned by you"
+         control_name="FSUseAntiSpamMine"
+         enabled_control="UseAntiSpam"
+         follows="left|top"
+         height="16"
+         name="FSUseAntiSpamMine"
+         width="380"
+         tool_tip="This will apply antispam protection even to objects you own."/>
+        <!-- /FS:TS FIRE-23138 -->
+        <text
+         top_pad="5"
+         type="string"
+         length="1"
+         follows="left|top"
+         height="15"
+         layout="topleft"
+         left="30"
+         name="AntiSpamText1"
+         width="200">
+           Max lines in a single message:
+        </text>
+        <spinner
+         enabled_control="UseAntiSpam"
+         top_delta="-5"
+         control_name="_NACL_AntiSpamNewlines"
+         decimal_digits="0"
+         layout="topleft"
+         follows="left|top"
+         height="18"
+         left_pad="0"
+         increment="1"
+         initial_value="70"
+         max_val="1000"
+         min_val="5"
+         name="_NACL_AntiSpamNewlines"
+         width="50"
+         tool_tip="Maximum number of lines to accept in a single text message [Default: 70]"/>
+        <text
+         top_pad="10"
+         type="string"
+         length="1"
+         follows="left|top"
+         height="15"
+         layout="topleft"
+         left="30"
+         name="AntiSpamText2"
+         width="200">
+           Max events from same source:
+        </text>
+        <spinner
+         enabled_control="UseAntiSpam"
+         top_delta="-5"
+         control_name="_NACL_AntiSpamAmount"
+         decimal_digits="0"
+         layout="topleft"
+         follows="left|top"
+         height="18"
+         left_pad="0"
+         increment="1"
+         initial_value="10"
+         max_val="40"
+         min_val="2"
+         name="_NACL_AntiSpamAmount"
+         width="50"
+         tool_tip="Maximum number of similar events to accept within 2 seconds from the same source [Default: 10]"/>
+        <text
+         top_pad="10"
+         type="string"
+         length="1"
+         follows="left|top"
+         height="15"
+         layout="topleft"
+         left="30"
+         name="AntiSpamText3"
+         width="200">
+           Sound play requests multiplier:
+        </text>
+        <spinner
+         enabled_control="UseAntiSpam"
+         top_delta="-5"
+         control_name="_NACL_AntiSpamSoundMulti"
+         decimal_digits="0"
+         layout="topleft"
+         follows="left|top"
+         height="18"
+         left_pad="0"
+         increment="1"
+         initial_value="10"
+         max_val="25"
+         min_val="1"
+         name="_NACL_AntiSpamSoundMulti"
+         width="50"
+         tool_tip="Event multiplier for sound play requests [Default: 10]"/>
+        <text
+         top_pad="10"
+         type="string"
+         length="1"
+         follows="left|top"
+         height="15"
+         layout="topleft"
+         left="30"
+         name="AntiSpamText4"
+         width="200">
+           Sound preload requests multiplier:
+        </text>
+        <spinner
+         enabled_control="UseAntiSpam"
+         top_delta="-5"
+         control_name="_NACL_AntiSpamSoundPreloadMulti"
+         decimal_digits="0"
+         layout="topleft"
+         follows="left|top"
+         height="18"
+         left_pad="0"
+         increment="1"
+         initial_value="4"
+         max_val="25"
+         min_val="1"
+         name="_NACL_AntiSpamSoundPreloadMulti"
+         width="50"
+         tool_tip="Event multiplier for sound preload requests [Default: 4]"/>
+        <button
+         enabled_control="UseAntiSpam"
+         layout="topleft"
+         follows="left|top"
+         top_pad="10"
+         width="200"
+         height="20"
+         left="40"
+         name="AntiSpamUnblock"
+         label="Unblock all spam sources"
+         commit_callback.function="NACL.AntiSpamUnblock"/>
+
+        <check_box
+         top_pad="8"
+         left="10"
+         label="Confirm before paying. Threshold:"
+         control_name="FSConfirmPayments"
+         follows="left|top"
+         height="16"
+         name="FSConfirmPayments"
+         width="205"
+         tool_tip="Show a confirmation dialog before paying sums greater than the threshold. To always show a confirmation, set the threshold to 0."/>
+        <spinner
+         enabled_control="FSConfirmPayments"
+         top_delta="-5"
+         control_name="FSPaymentConfirmationThreshold"
+         decimal_digits="0"
+         layout="topleft"
+         follows="left|top"
+         height="18"
+         left_pad="5"
+         increment="1"
+         initial_value="200"
+         max_val="2147483647"
+         min_val="0"
+         name="FSPaymentConfirmationThreshold"
+         tool_tip="Show a confirmation dialog before paying sums greater than the threshold. To always show a confirmation, set the threshold to 0."
+         width="100"/>
+    </panel>
+
+
+    <!--Avatar-->
+    <panel
+     top_pad="5"
+     bottom="-1"
+     left="1"
+     right="-1"
+     follows="all"
+     label="Avatar"
+     name="aperture_avatar" >
+
+        <text
+         type="string"
+         left="5"
+         top_pad="12"
+         length="1"
+         follows="left|top"
+         height="12"
+         layout="topleft"
+         name="HeadMovement"
+         width="500">
+            Amount that Avatar's head Follows Mouse (set to '0' for no movement):
+        </text>
+        <slider
+         control_name="PitchFromMousePosition"
+         decimal_digits="0"
+         follows="left|top"
+         height="16"
+         increment="15"
+         label="Vertical range that avatar's head follows mouse:"
+         tool_tip="Vertical range that avatar's head follows mouse (pitch) in degrees"
+         label_width="300"
+         layout="topleft"
+         left="15"
+         min_val="0"
+         max_val="120"
+         name="PitchFromMousePositionSlider"
+         top_pad="10"
+         width="471" />
+        <text
+         type="string"
+         length="1"
+         follows="left|top"
+         height="16"
+         layout="topleft"
+         left="485"
+         name="PitchFromMousePositionText"
+         top_delta="0"
+         width="50">
+            degrees
+        </text>
+        <slider
+         control_name="YawFromMousePosition"
+         decimal_digits="0"
+         follows="left|top"
+         height="16"
+         increment="5"
+         label="Horizontal range that avatar's head follows mouse:"
+         tool_tip="Horizontal range that avatar's head follows mouse (yaw) in degrees"
+         label_width="300"
+         layout="topleft"
+         left="15"
+         min_val="0"
+         max_val="120"
+         name="YawFromMousePositionSlider"
+         top_pad="5"
+         width="471" />
+        <text
+         type="string"
+         length="1"
+         follows="left|top"
+         height="16"
+         layout="topleft"
+         left="485"
+         name="YawFromMousePositionText"
+         top_delta="0"
+         width="50">
+            degrees
+        </text>
+        <text
+         top_pad="5"
+         left="15"
+         name="note_lookat"
+         follows="left|top"
+         layout="topleft"
+         text_color="White_50"
+         height="12"
+         width="500">
+             (Avatar look at target settings are on the Privacy tab.)
+        </text>
+
+        <check_box
+         top_pad="10"
+         enabled="false"
+         follows="left|top"
+         height="16"
+         label="Disable random avatar eye movements"
+         left="15"
+         name="FSStaticEyes"
+         width="250"
+         control_name="FSStaticEyes"/>
+
+        <!-- LGG Color Beams -->
+        <text
+         name="BeamPrefs"
+         follows="left|top"
+         left="15"
+         bottom_delta="25" >
+            Selection beam particle effects
+        </text>
+        <view_border
+         bevel_style="none"
+         border_thickness="1"
+         top_delta="15"
+         follows="top|left"
+         height="0"
+         left="15"
+         name="BeamDivisor"
+         width="490" />
+
+        <button
+         enabled_control="ShowSelectionBeam"
+         name="BeamColor_delete"
+         label="Delete"
+         tool_tip="Remove this preset"
+         left="15"
+         top_delta="10"
+         width="55"
+         height="20"
+         follows="left|top" />
+
+        <combo_box
+         enabled_control="ShowSelectionBeam"
+         allow_text_entry="false"
+         top_delta="0"
+         left_delta="60"
+         follows="left|top"
+         height="20"
+         max_chars="20"
+         name="BeamColor_combo"
+         width="170"
+         control_name="FSBeamColorFile"
+         tool_tip="Select the color preset for the selection beam"/>
+
+        <button
+         enabled_control="ShowSelectionBeam"
+         name="BeamColor_new"
+         label="Create New"
+         tool_tip="Create a new color preset"
+         left="15"
+         bottom_delta="25"
+         width="80"
+         height="20"
+         follows="left|top" />
+
+        <button
+         enabled_control="ShowSelectionBeam"
+         name="BeamColor_refresh"
+         label="Refresh List"
+         tool_tip="Refresh the preset list"
+         left="15"
+         bottom_delta="25"
+         width="80"
+         height="20"
+         follows="left|top" />
+
+        <button
+         enabled_control="ShowSelectionBeam"
+         left="100"
+         top_delta="-25"
+         follows="left|top"
+         width="130"
+         height="80"
+         name="PhoenixBeamPrev_rainbow"
+         label=""
+         scale_image="true"
+         image_color="SL-White"
+         image_color_disabled="SL-White"
+         image_selected="beam_rainbow.png"
+         image_unselected="beam_rainbow.png"
+         image_hover_selected="beam_rainbow.png"
+         image_hover_unselected="beam_rainbow.png" />
+
+        <slider
+         enabled_control="ShowSelectionBeam"
+         bottom_delta="25"
+         left="15"
+         name="FSMaxBeamsPerSecond"
+         control_name="FSMaxBeamsPerSecond"
+         decimal_digits="0"
+         enabled="true"
+         follows="left|top"
+         height="18"
+         increment="1"
+         initial_value="4"
+         label="Beam updates/sec:"
+         label_width="100"
+         max_val="200"
+         min_val="4"
+         show_text="true"
+         width="250"
+         tool_tip="How many beam updates to send in a second. Default 40" />
+
+        <check_box
+         bottom_delta="18"
+         enabled="true"
+         follows="left|top"
+         height="16"
+         initial_value="true"
+         label="Enable selection beam"
+         left="15"
+         name="SLPartBeam"
+         width="250"
+         tool_tip="Disabling this setting will prevent selection beams from being rendered locally. It does not prevent selection beams being sent to other avatars. If you do not wish to show your selection, you can disable that via Preferences -&gt; Privacy -&gt; LookAt -&gt; Don't send my selection target hints."
+         control_name="ShowSelectionBeam" />
+
+        <check_box
+         bottom_delta="18"
+         enabled="true"
+         follows="left|top"
+         height="16"
+         initial_value="true"
+         label="Send selection data to chat"
+         left="15"
+         name="FSParticleChat"
+         tool_tip="Sends selection data (selection start/stop and global position) to chat channel 9000."
+         width="250"
+         control_name="FSParticleChat" />
+
+        <view_border
+         bevel_style="none"
+         border_thickness="1"
+         top_delta="-160"
+         follows="top|left"
+         height="180"
+         left="260"
+         name="BeamDivisor2"
+         width="0" />
+
+        <combo_box
+         enabled_control="ShowSelectionBeam"
+         allow_text_entry="false"
+         bottom_delta="-150"
+         left="275"
+         follows="left|top"
+         height="20"
+         max_chars="20"
+         name="FSBeamShape_combo"
+         width="170"
+         control_name="FSBeamShape"
+         tool_tip="Select the shape for the particle beam" />
+
+        <button
+         enabled_control="ShowSelectionBeam"
+         name="delete_beam"
+         label="Delete"
+         tool_tip="Remove this beam"
+         left_delta="175"
+         bottom_delta="0"
+         width="55"
+         height="20"
+         follows="left|top" />
+
+        <button
+         enabled_control="ShowSelectionBeam"
+         name="custom_beam_btn"
+         label="Create New"
+         tool_tip="Customize the beam shape"
+         left_delta="-20"
+         bottom_delta="25"
+         width="80"
+         height="20"
+         follows="left|top"/>
+
+        <button
+         enabled_control="ShowSelectionBeam"
+         name="refresh_beams"
+         label="Refresh List"
+         tool_tip="Refresh the beam list"
+         left_delta="0"
+         bottom_delta="25"
+         width="80"
+         height="20"
+         follows="left|top" />
+
+        <button
+         enabled_control="ShowSelectionBeam"
+         left="290"
+         top_delta="-25"
+         follows="left|top"
+         width="130"
+         height="80"
+         name="PhoenixBeamPrev_Phoenix"
+         label=""
+         image_color="SL-White"
+         image_color_disabled="SL-White"
+         scale_image="true"
+         image_selected="beam_phoenix.png"
+         image_unselected="beam_phoenix.png"
+         image_hover_selected="beam_phoenix.png"
+         image_hover_unselected="beam_phoenix.png" />
+
+        <slider
+         enabled_control="ShowSelectionBeam"
+         bottom_delta="25"
+         left_delta="-15"
+         name="FSBeamShapeScale"
+         control_name="FSBeamShapeScale"
+         decimal_digits="1"
+         enabled="true"
+         follows="left|top"
+         height="18"
+         increment="0.1"
+         initial_value="1"
+         label="Scale:"
+         label_width="35"
+         max_val="4"
+         min_val="0.1"
+         show_text="true"
+         width="150"
+         tool_tip="Change the scale of the shape used for the Phoenix Shaped Beam" />
+
+        <text
+         type="string"
+         left="5"
+         top_pad="65"
+         length="1"
+         follows="left|top"
+         height="12"
+         layout="topleft"
+         name="BridgeProtocols"
+         width="500">
+            LSL-Client Bridge external protocols integration:
+        </text>
+        <check_box
+         follows="left|top"
+         height="16"
+         label="Allow OpenCollar protocol to enable or disable built in AO"
+         left="15"
+         top_pad="10"
+         name="BridgeIntegrationOC"
+         width="450"
+         enabled_control="UseLSLBridge"
+         control_name="BridgeIntegrationOC" />
+        <check_box
+         follows="left|top"
+         height="16"
+         label="Allow LockMeister protocol to enable or disable built in AO"
+         left="15"
+         top_pad="2"
+         name="BridgeIntegrationLM"
+         width="450"
+         enabled_control="UseLSLBridge"
+         control_name="BridgeIntegrationLM" />
+
+    </panel>
+
+    <!--Build 1-->
+    <panel
+     top_pad="5"
+     bottom="-1"
+     left="1"
+     right="-1"
+     follows="all"
+     label="Build 1"
+     name="BuildTab">
+     
+        <text
+         top="5"
+         follows="left|top|right"
+         height="10"
+         left="20"
+         name="text_box_objprams"
+         width="175">
+         Default Object Size
+        </text>
+        <text
+         top="5"
+         follows="left|top|right"
+         height="10"
+         left="180"
+         name="text_box_objprams2"
+         width="175">
+         Settings
+        </text>
+        <text
+         top="5"
+         follows="left|top|right"
+         height="10"
+         left="350"
+         name="text_box_objprams3"
+         width="175">
+         Texture
+        </text>
+        <view_border
+         top_pad="5"
+         left="5"
+         height="90"
+         follows="top|left"
+         bevel_style="none"
+         border_thickness="1"
+         name="SizeBorder"
+         width="140"/>
+        <view_border
+         top_delta="0"
+         left_delta="140"
+         height="90"
+         follows="top|left"
+         bevel_style="none"
+         border_thickness="1"
+         name="SettingBorder"
+         width="120"/>
+        <view_border
+         top_delta="0"
+         left_delta="120"
+         height="90"
+         follows="top|left"
+         bevel_style="none"
+         border_thickness="1"
+         name="TextureBorder"
+         width="255"/>
+         
+        <spinner
+         top_pad="-77"
+         left="15"
+         decimal_digits="5"
+         follows="left|top"
+         height="16"
+         increment="0.05"
+         label="X size"
+         label_width="40"
+         max_val="10"
+         min_val="0.01"
+         name="X size"
+         width="120"
+         control_name="FSBuildPrefs_Xsize"/>
+        <spinner
+         top_pad="7"
+         decimal_digits="5"
+         follows="left|top"
+         height="16"
+         increment="0.05"
+         label="Y size"
+         label_width="40"
+         max_val="10"
+         min_val="0.01"
+         name="Y size"
+         width="120"
+         control_name="FSBuildPrefs_Ysize"/>
+        <spinner
+         top_pad="7"
+         decimal_digits="5"
+         follows="left|top"
+         height="16"
+         increment="0.05"
+         label="Z size"
+         label_width="40"
+         max_val="10"
+         min_val="0.01"
+         name="Z size"
+         width="120"
+         control_name="FSBuildPrefs_Zsize"/>
+
+        <check_box
+         top_delta="-50"
+         enabled="true"
+         follows="left|top"
+         font="SansSerifSmall"
+         height="16"
+         label="Phantom"
+         left="155"
+         mouse_opaque="true"
+         name="FSBuildPrefs_PhantomToggle"
+         radio_style="false"
+         width="100"
+         control_name="FSBuildPrefs_Phantom"/>
+        <check_box
+         top_delta="20"
+         enabled="true"
+         follows="left|top"
+         font="SansSerifSmall"
+         height="16"
+         label="Physical"
+         left_delta="0"
+         mouse_opaque="true"
+         name="FSBuildPrefs_PhysicalToggle"
+         radio_style="false"
+         width="100"
+         control_name="FSBuildPrefs_Physical"/>
+        <check_box
+         top_delta="20"
+         enabled="true"
+         follows="left|top"
+         font="SansSerifSmall"
+         height="16"
+         label="Temporary"
+         left_delta="0"
+         mouse_opaque="true"
+         name="FSBuildPrefs_TemporaryToggle"
+         radio_style="false"
+         width="100"
+         control_name="FSBuildPrefs_Temporary"/>
+        <combo_box
+         allow_text_entry="false"
+         top_delta="20"
+         left_delta="1"
+         follows="left|top"
+         height="18"
+         max_chars="20"
+         mouse_opaque="true"
+         name="material"
+         width="87"
+         control_name="FSBuildPrefs_Material">
+             <combo_item name="Stone" value="Stone" label="Stone"/>
+             <combo_item name="Metal" value="Metal" label="Metal"/>
+             <combo_item name="Glass" value="Glass" label="Glass"/>
+             <combo_item name="Wood" value="Wood" label="Wood"/>
+             <combo_item name="Flesh" value="Flesh" label="Flesh"/>
+             <combo_item name="Plastic" value="Plastic" label="Plastic"/>
+             <combo_item name="Rubber" value="Rubber" label="Rubber"/>
+        </combo_box>
+
+        <texture_picker
+         allow_no_texture="false"
+         top_delta="-60"
+         can_apply_immediately="true"
+         default_image_name="Default"
+         follows="left|top"
+         height="80"
+         label="Texture"
+         left="275"
+         mouse_opaque="true"
+         name="texture control"
+         control_name="FSDefaultObjectTexture"
+         tool_tip="Click to choose a picture"
+         width="64"/>
+        <color_swatch
+         border_color="0.45098, 0.517647, 0.607843, 1"
+         top_delta="0"
+         can_apply_immediately="true"
+         color="1, 1, 1, 1"
+         follows="left|top"
+         height="80"
+         label="Color"
+         left_delta="75"
+         mouse_opaque="true"
+         name="colorswatch"
+         tool_tip="Click to open Color Picker"
+         width="64"
+         control_name="FSBuildPrefs_Color"/>
+        <spinner
+         top_delta="0"
+         decimal_digits="0"
+         follows="left|top"
+         height="16"
+         increment="1"
+         label="Alpha"
+         label_width="40"
+         left_delta="70"
+         max_val="100"
+         min_val="0"
+         mouse_opaque="true"
+         name="alpha"
+         width="90"
+         control_name="FSBuildPrefs_Alpha"/>
+        <spinner
+         top_delta="20"
+         enabled="true"
+         decimal_digits="2"
+         follows="left|top"
+         height="16"
+         increment="0.05"
+         label="Glow"
+         label_width="40"
+         left_delta="0"
+         max_val="1"
+         min_val="0"
+         mouse_opaque="true"
+         name="glow"
+         width="90"
+         control_name="FSBuildPrefs_Glow"/>
+        <check_box
+         top_delta="22"
+         enabled="true"
+         follows="left|top"
+         font="SansSerifSmall"
+         height="16"
+         label="Full Bright"
+         left_delta="0"
+         mouse_opaque="true"
+         name="EmFBToggle"
+         radio_style="false"
+         width="100"
+         control_name="FSBuildPrefs_FullBright"/>
+        <combo_box
+         allow_text_entry="false"
+         top_delta="18"
+         follows="left|top"
+         height="18"
+         left_delta="0"
+         max_chars="20"
+         mouse_opaque="true"
+         name="combobox shininess"
+         tool_tip="Set the amount of shine for the object"
+         width="90"
+         control_name="FSBuildPrefs_Shiny">
+          <combo_item name="None" value="None" label="None"/>
+          <combo_item name="Low" value="Low" label="Low"/>
+          <combo_item name="Medium" value="Medium" label="Medium"/>
+          <combo_item name="High" value="High" label="High"/>
+        </combo_box>
+        <check_box
+         name="FSBuildPrefs_EmbedItem"
+         top="120"
+         enabled="false"
+         follows="left|top"
+         font="SansSerifSmall"
+         height="16"
+         initial_value="false"
+         label="Embed an item into new prims"
+         left="10"
+         mouse_opaque="true"
+         control_name="FSBuildPrefs_EmbedItem"
+         radio_style="false"
+         width="270"/>
+        <view_border
+         bevel_style="in"
+         top_delta="20"
+         follows="left|top"
+         height="16"
+         left_delta="0"
+         mouse_opaque="false"
+         name="embed_item_drop_target_rect"
+         width="250"/>
+        <fs_embedded_item_drop_target
+         bg_visible="false"
+         border_visible="false"
+         top_delta="0"
+         follows="left|top"
+         font="SansSerifSmall"
+         h_pad="0"
+         halign="center"
+         height="16"
+         left_delta="0"
+         mouse_opaque="true"
+         name="embed_item"
+         tool_tip="Drop an inventory item here."
+         v_pad="2"
+         width="250">
+         Drop an inventory item here.
+        </fs_embedded_item_drop_target>
+        <view_border
+         bevel_style="in"
+         top_delta="18"
+         follows="left|top"
+         height="16"
+         left_delta="0"
+         mouse_opaque="false"
+         name="build_item_add_disp_rect"
+         width="250"/>
+        <text
+         bg_visible="false"
+         border_visible="false"
+         top_delta="0"
+         follows="left|top"
+         font="SansSerifSmall"
+         h_pad="0"
+         halign="center"
+         height="16"
+         left_delta="0"
+         mouse_opaque="true"
+         name="build_item_add_disp_rect_txt"
+         tool_tip=""
+         v_pad="2"
+         width="250">
+         Currently set to: [ITEM]
+        </text>
+        <text
+         top_pad="-60"
+         left_pad="125"
+         follows="left|top"
+         height="10"
+         name="text_box_pivotpoint"
+         width="135">
+          Pivot Point
+        </text>
+        <view_border
+         top_pad="5"
+         bevel_style="none"
+         border_thickness="1"
+         follows="top|left"
+         height="120"
+         name="PivotBorder"
+         width="135"/>
+        <check_box
+         top_delta="13"
+         left_delta="3"
+         follows="left|top"
+         label="Axis on root prim"
+         tool_tip="Default behaviour is to show the axis on the center of mass of a linkset. If enabled, the axis will be shown on the root prim of the linkset instead."
+         name="FSBuildPrefsActualRoot_toggle"
+         control_name="FSBuildPrefs_ActualRoot"/>
+        <spinner
+         top_pad="5"
+         left_delta="5"
+         decimal_digits="5"
+         follows="left|top"
+         height="16"
+         increment="0.05"
+         label="X pos"
+         label_width="40"
+         max_val="256"
+         min_val="-256"
+         name="X pos"
+         width="120"
+         control_name="FSBuildPrefs_PivotX"/>
+        <spinner
+         top_pad="7"
+         decimal_digits="5"
+         follows="left|top"
+         height="16"
+         increment="0.05"
+         label="Y pos"
+         label_width="40"
+         max_val="256"
+         min_val="-256"
+         name="Y pos"
+         width="120"
+         control_name="FSBuildPrefs_PivotY"/>
+        <spinner
+         top_pad="7"
+         decimal_digits="5"
+         follows="left|top"
+         height="16"
+         increment="0.05"
+         label="Z pos"
+         label_width="40"
+         max_val="256"
+         min_val="-256"
+         name="Z pos"
+         width="120"
+         control_name="FSBuildPrefs_PivotZ"/>
+        <check_box
+         top_pad="10"
+         left_delta="-3"
+         enabled="true"
+         follows="left|top"
+         height="16"
+         label="Values are percent"
+         tool_tip="Default settings are Percentages and every axis set at 50"
+         name="FSPivotPercToggle"
+         width="100"
+         control_name="FSBuildPrefs_PivotIsPercent"/>
+
+        <button
+         follows="left|top"
+         height="25"
+         label="Default Creation Permissions"
+         layout="topleft"
+         name="fs_default_creation_permissions"
+         left="8"
+         top="185"
+         width="250">
+         <button.commit_callback
+             function="Pref.PermsDefault" />
+        </button>
+
+        <text
+         top_pad="10"
+         left="8"
+         follows="left|top"
+         name="text_box_scripting_font"
+         width="100">
+          Script Editor Font:
+        </text>
+        <combo_box
+         allow_text_entry="false"
+         top_delta="-5"
+         left_pad="5"
+         follows="left|top"
+         max_chars="20"
+         mouse_opaque="true"
+         name="FSScriptingFontName"
+         width="100"
+         control_name="FSScriptingFontName"
+         tool_tip="Name of the font used in the LSL script editor">
+             <combo_item name="Monospace" value="Monospace" label="Monospace"/>
+             <combo_item name="Scripting" value="Scripting" label="Scripting"/>
+             <combo_item name="Cascadia" value="Cascadia" label="Cascadia Code"/>
+        </combo_box>
+        <combo_box
+         allow_text_entry="false"
+         top_delta="0"
+         left_pad="5"
+         follows="left|top"
+         max_chars="20"
+         mouse_opaque="true"
+         name="FSScriptingFontSize"
+         width="100"
+         control_name="FSScriptingFontSize"
+         tool_tip="Size of the font used in the LSL script editor">
+             <combo_item name="Monospace" value="Monospace" label="Monospace"/>
+             <combo_item name="Scripting" value="Scripting" label="Scripting"/>
+             <combo_item name="Cascadia" value="Cascadia" label="Cascadia Code"/>
+             <combo_item name="Small" value="Small" label="Small"/>
+             <combo_item name="Medium" value="Medium" label="Medium"/>
+             <combo_item name="Large" value="Large" label="Large"/>
+        </combo_box>
+
+        <check_box
+         follows="left|top"
+         height="16"
+         top_pad="10"
+         left="5"
+         label="Enable LSL preprocessor"
+         tool_tip="When checked, the LSL preprocessor is enabled."
+         name="preproc_checkbox"
+         control_name="_NACL_LSLPreprocessor" />
+        <check_box
+         follows="left|top"
+         height="16"
+         left="15"
+         enabled_control="_NACL_LSLPreprocessor"
+         label="Script optimizer"
+         tool_tip="When checked, the LSL preprocessor will optimize space used by scripts."
+         name="preprocoptimizer_checkbox"
+         control_name="_NACL_PreProcLSLOptimizer" />
+        <check_box
+         follows="left|top"
+         height="16"
+         top_delta="0"
+         left_delta="120"
+         enabled_control="_NACL_LSLPreprocessor"
+         label="switch() statement"
+         tool_tip="When checked, the LSL preprocessor will allow the use of the switch() statement for script flow control."
+         name="preprocswitch_checkbox"
+         control_name="_NACL_PreProcLSLSwitch" />
+        <check_box
+         follows="left|top"
+         height="16"
+         top_delta="0"
+         left_delta="130"
+         enabled_control="_NACL_LSLPreprocessor"
+         label="Lazy lists"
+         tool_tip="When checked, the LSL preprocessor will allow the use of syntax extensions for list handling."
+         name="preproclazy_checkbox"
+         control_name="_NACL_PreProcLSLLazyLists" />
+        <check_box
+         follows="left|top"
+         top_delta="0"
+         left_delta="80"
+         height="16"
+         enabled_control="_NACL_LSLPreprocessor"
+         label="#includes from local disk"
+         tool_tip="When checked, the LSL preprocessor will allow #include statements to reference files on your local disk."
+         name="preprocinclude_checkbox"
+         control_name="_NACL_PreProcEnableHDDInclude" />
+        <text
+         follows="left|top"
+         height="16"
+         type="string"
+         length="1"
+         layout="topleft"
+         enabled_control="_NACL_PreProcEnableHDDInclude"
+         name="lslpreprocinclude_textbox"
+         left="10"
+         width="256">
+          Preprocessor include path:
+        </text>
+        <line_editor
+         control_name="_NACL_PreProcHDDIncludeLocation"
+         border_style="line"
+         border_thickness="1"
+         follows="left|top"
+         font="SansSerif"
+         height="23"
+         enabled_control="_NACL_PreProcEnableHDDInclude"
+         max_length_chars="4096"
+         name="preprocinclude_location"
+         width="310" />
+        <button
+         follows="left|top"
+         height="23"
+         enabled_control="_NACL_PreProcEnableHDDInclude"
+         label="Browse"
+         label_selected="Browse"
+         left_pad="5"
+         name="SetPreprocInclude"
+         top_delta="0"
+         width="100">
+         <button.commit_callback
+          function="NACL.SetPreprocInclude" />
+        </button>
+        <text
+         follows="left|top"
+         height="16"
+         type="string"
+         length="1"
+         layout="topleft"
+         name="externaleditor_textbox"
+         left="10"
+         width="256">
+          External Editor:
+        </text>
+        <line_editor
+         control_name="ExternalEditor"
+         border_style="line"
+         border_thickness="1"
+         follows="left|top"
+         font="SansSerif"
+         height="23"
+         max_length_chars="4096"
+         name="externaleditor_location"
+         width="310" />
+        <button
+         follows="left|top"
+         height="23"
+         label="Browse"
+         label_selected="Browse"
+         left_pad="5"
+         name="SetExternalEditor"
+         top_delta="0"
+         width="100">
+         <button.commit_callback
+          function="Pref.SetExternalEditor" />
+        </button>
+  </panel>
+
+    <!--Build 2-->
+    <panel
+     top_pad="5"
+     bottom="-1"
+     left="1"
+     right="-1"
+     follows="all"
+     label="Build 2"
+     name="BuildTab2">
+        <check_box
+         top="10"
+         follows="left|top"
+         height="16"
+         left="3"
+         label="Enable highlighting of selected prims"
+         tool_tip="When unchecked, the yellow/blue outline effects are not rendered, improving performance when large numbers of prims are selected."
+         name="FSBuildPrefsRenderHighlight_toggle"
+         control_name="RenderHighlightSelections"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Highlight boundary of currently selected parcel"
+         name="RenderParcelSelection"
+         control_name="RenderParcelSelection"
+         width="190"/>
+        <check_box
+         enabled_control="RenderParcelSelection"
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         left="13"
+         label="Show boundary up to maximum build height"
+         name="FSRenderParcelSelectionToMaxBuildHeight"
+         control_name="FSRenderParcelSelectionToMaxBuildHeight"
+         width="190"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         left="3"
+         label="Limit select distance (meters):"
+         name="LimitSelectDistance"
+         control_name="LimitSelectDistance"
+         width="190"/>
+        <spinner
+         enabled_control="LimitSelectDistance"
+         control_name="MaxSelectDistance"
+         decimal_digits="3"
+         top_delta="-5"
+         left_pad="0"
+         follows="left|top"
+         height="16"
+         increment="0.01"
+         max_val="1024"
+         min_val="0.001"
+         name="MaxSelectDistance"
+         width="75"
+         tool_tip="Maximum allowed selection distance (meters from avatar) [Default: 128.000]"/>
+        <check_box
+         left="3"
+         top_pad="13"
+         follows="left|top"
+         height="16"
+         label="Limit drag distance (meters):"
+         name="LimitDragDistance"
+         control_name="LimitDragDistance"
+         width="190"/>
+        <spinner
+         enabled_control="LimitDragDistance"
+         control_name="MaxDragDistance"
+         decimal_digits="3"
+         top_delta="-5"
+         left_pad="0"
+         follows="left|top"
+         height="16"
+         increment="0.01"
+         max_val="1024"
+         min_val="0.001"
+         name="MaxDragDistance"
+         width="75"
+         tool_tip="Maximum allowed distance in a single operation of move tool (meters from start point) [Default: 48.000]"/>
+        <text
+         left="3"
+         top_pad="13"
+         follows="left|top"
+         height="16"
+         name="RotationStepText1"
+         width="190">
+          Constrain rotations to multiples of
+        </text>
+        <spinner
+         control_name="RotationStep"
+         decimal_digits="2"
+         top_delta="-5"
+         left_pad="0"
+         follows="left|top"
+         height="16"
+         increment="0.01"
+         max_val="359.99"
+         min_val="0.01"
+         name="RotationStep"
+         width="65"
+         tool_tip="All rotations via rotation tool are constrained to multiples of this unit [Default: 1.0]"/>
+        <text
+         left_pad="5"
+         top_pad="-11"
+         follows="left|top"
+         height="16"
+         name="RotationStepText2"
+         width="270">
+          degrees, when not using 'snap to grid'
+        </text>
+        <check_box
+         left="3"
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Show unlink confirmation dialog if linkset has minimum"
+         name="FSUnlinkConfirmEnabled"
+         control_name="FSUnlinkConfirmEnabled"
+         width="325"/>
+        <spinner
+         enabled_control="FSUnlinkConfirmEnabled"
+         control_name="MinObjectsForUnlinkConfirm"
+         decimal_digits="0"
+         top_delta="-5"
+         left_pad="0"
+         follows="left|top"
+         height="16"
+         increment="1"
+         max_val="256"
+         min_val="0"
+         name="MinObjectsForUnlinkConfirm"
+         width="65"/>
+        <text
+         left_pad="5"
+         top_pad="-11"
+         follows="left|top"
+         height="16"
+         name="MinObjectsForUnlinkConfirmText2"
+         width="270">
+          objects
+        </text>
+        <check_box
+         left="3"
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Use old &quot;Set Object For Sale&quot; behavior"
+         tool_tip="When checked, object for sale info is saved on change instead of requiring a confirm."
+         name="FSCommitForSaleOnChange_toggle"
+         control_name="FSCommitForSaleOnChange"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Save scripts edited from inventory as Mono"
+         tool_tip="When checked, editing a script directly from inventory and then saving it saves as Mono instead of LSL."
+         name="FSSaveInventoryScriptsAsMono_toggle"
+         control_name="FSSaveInventoryScriptsAsMono"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Save textures from inventory to disk as PNG instead of TGA by default"
+         tool_tip="Used in the texture preview floater and context menu in inventory."
+         name="FSTextureDefaultSaveAsFormat"
+         control_name="FSTextureDefaultSaveAsFormat"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Use Ctrl+mouse to grab and manipulate objects"
+         tool_tip="When checked, you will be able to grab and move objects with your mouse and CTRL key."
+         name="FSEnableGrab"
+         control_name="EnableGrab"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+		 initial_value="false"
+         label="Allow click-drag or click-scale (together with caps lock) of a texture face in build mode"
+         tool_tip="If enabled, allows to click-drag or click-scale (together with caps lock) a texture face in build mode. This feature is still experimental and should be used with caution."
+         name="FSExperimentalDragTexture"
+         control_name="FSExperimentalDragTexture"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Preview animations on own avatar during upload"
+         tool_tip="If enabled, you can preview animations during the upload process on your own avatar"
+         name="FSUploadAnimationOnOwnAvatar"
+         control_name="FSUploadAnimationOnOwnAvatar"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Always expand animation preview advanced information"
+         tool_tip="Expand the advanced animation information in the animation preview floater by default"
+         name="FSAnimationPreviewExpanded"
+         control_name="FSAnimationPreviewExpanded"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Enable extended script info details"
+         tool_tip="If enabled, extend basic script info feature with various details useful for builders"
+         name="FSScriptInfoExtended"
+         enabled_control="UseLSLBridge"
+         control_name="FSScriptInfoExtended"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Sort attachment spots in &quot;Attach to&quot; menus alphabetically (requires restart)"
+         tool_tip="If enabled, the list of attachments spots in the &amp;Attach to&amp; menus will be sorted alphabetically"
+         name="FSSortAttachmentSpotsAlphabetically"
+         control_name="FSSortAttachmentSpotsAlphabetically"/>
+        <check_box
+         top_pad="8"
+         follows="left|top"
+         height="16"
+         label="Use the new [APP_NAME] texture panel in the tools floater (requires restart)"
+         tool_tip="If enabled, the texture editing tools will use the refined [APP_NAME] workflow and allow editing of both Blinn-Phong and PBR textures."
+         name="FSUseNewTexturePanel"
+         control_name="FSUseNewTexturePanel"/>
+    </panel>
+
+    <!--Uploads-->
+    <panel
+     top_pad="5"
+     bottom="-1"
+     left="1"
+     right="-1"
+     follows="all"
+     label="Uploads"
+     name="UploadsTab">
+      <text
+       type="string"
+       length="1"
+       follows="left|top"
+       height="12"
+       layout="topleft"
+       left="10"
+       name="title"
+       top_pad="10"
+       width="250">
+        Current destination folders for uploads:
+      </text>
+
+      <text
+       type="string"
+       length="1"
+       follows="left|top"
+       height="12"
+       layout="topleft"
+       left="10"
+       name="title_images"
+       top_pad="17"
+       width="100">
+        Images
+      </text>
+      <text
+       type="string"
+       use_ellipses="true"
+       follows="left|top"
+       height="27"
+       layout="topleft"
+       font.style="BOLD"
+       left="10"
+       name="upload_textures"
+       top_pad="5"
+       width="370"
+       word_wrap="true" />
+      
+      <text
+       type="string"
+       length="1"
+       follows="left|top"
+       height="12"
+       layout="topleft"
+       left="10"
+       name="title_sounds"
+       top_pad="7"
+       width="100">
+        Sounds
+      </text>
+      <text
+       type="string"
+       use_ellipses="true"
+       follows="left|top"
+       height="27"
+       layout="topleft"
+       font.style="BOLD"
+       left="10"
+       name="upload_sounds"
+       top_pad="5"
+       width="370"
+       word_wrap="true" />
+      
+      <text
+       type="string"
+       length="1"
+       follows="left|top"
+       height="12"
+       layout="topleft"
+       left="10"
+       name="title_animations"
+       top_pad="7"
+       width="100">
+        Animations
+      </text>
+      <text
+       type="string"
+       use_ellipses="true"
+       follows="left|top"
+       height="27"
+       layout="topleft"
+       font.style="BOLD"
+       left="10"
+       name="upload_animation"
+       top_pad="5"
+       width="370"
+       word_wrap="true" />
+
+      <text
+       type="string"
+       length="1"
+       follows="left|top"
+       height="12"
+       layout="topleft"
+       left="10"
+       name="title_models"
+       top_pad="7"
+       width="100">
+        Models
+      </text>
+      <text
+       type="string"
+       use_ellipses="true"
+       follows="left|top"
+       height="27"
+       layout="topleft"
+       font.style="BOLD"
+       left="10"
+       name="upload_models"
+       top_pad="5"
+       width="370"
+       word_wrap="true" />
+
+      <text
+       type="string"
+       length="1"
+       follows="left|top"
+       height="12"
+       layout="topleft"
+       left="10"
+       name="title_pbr"
+       top_pad="7"
+       width="100">
+        PBR Materials
+      </text>
+      <text
+       type="string"
+       use_ellipses="true"
+       follows="left|top"
+       height="27"
+       layout="topleft"
+       font.style="BOLD"
+       left="10"
+       name="upload_pbr"
+       top_pad="5"
+       width="370"
+       word_wrap="true" />
+
+      <text
+       type="string"
+       length="1"
+       follows="left|top"
+       height="30"
+       layout="topleft"
+       font.style="ITALIC"
+       left="10"
+       name="upload_help"
+       top_pad="6"
+       width="475">
+        To change a destination folder, right click on it in inventory and choose
+     "Use as default for"
+      </text>
+      <button
+       name="reset_default_folders"
+       label="Reset default folders"
+       left="10"
+       top_pad="10"
+       width="200"
+       follows="left|top" />
+    </panel>
+</tab_container>
+</panel>

--- a/indra/newview/skins/starlightcui/xui/en/floater_preferences.xml
+++ b/indra/newview/skins/starlightcui/xui/en/floater_preferences.xml
@@ -215,12 +215,12 @@ https://accounts.secondlife.com/change_email/
          help_topic="preferences_crashreports_tab"
          name="crashreports" />
         <panel
-         class="panel_preference_firestorm"
-         filename="panel_preferences_firestorm.xml"
-         label="Firestorm"
+         class="panel_preference_aperture"
+         filename="panel_preferences_aperture.xml"
+         label="Aperture"
          layout="topleft"
          help_topic="preferences_firestorm_tab"
-         name="firestorm" />
+         name="aperture" />
         <panel
          class="panel_preference_opensim"
          filename="panel_preferences_opensim.xml"

--- a/indra/newview/skins/vintage/xui/en/floater_preferences.xml
+++ b/indra/newview/skins/vintage/xui/en/floater_preferences.xml
@@ -198,12 +198,12 @@ https://accounts.secondlife.com/change_email/
          help_topic="preferences_crashreports_tab"
          name="crashreports" />
         <panel
-         class="panel_preference_firestorm"
-         filename="panel_preferences_firestorm.xml"
-         label="Firestorm"
+         class="panel_preference_aperture"
+         filename="panel_preferences_aperture.xml"
+         label="Aperture"
          layout="topleft"
          help_topic="preferences_firestorm_tab"
-         name="firestorm" />
+         name="aperture" />
         <panel
          class="panel_preference_opensim"
          filename="panel_preferences_opensim.xml"


### PR DESCRIPTION
This PR addresses enhancement / feature request of Issue https://github.com/ApertureViewer/Aperture-Viewer/issues/39 by rebranding the "Firestorm" tab in preferences to "Aperture

Addresses: https://github.com/ApertureViewer/Aperture-Viewer/issues/39

## Changelog

### Files changed


`indra/newview/fspanelprefs.cpp` - update the reference to `panel_preference_firestorm`
`indra/newview/skins/default/xui/en/floater_preferences.xml`  - rebranded Firestorm to Aperture
`indra/newview/skins/starlightcui/xui/en/floater_preferences.xml`  - rebranded Firestorm to Aperture
`indra/newview/skins/vintage/xui/en/floater_preferences.xml`  - rebranded Firestorm to Aperture

### New files

`indra/newview/skins/default/xui/en/panel_preferences_aperture.xml` - basically copy of the original.

## *Known Issues / Caveats

None that I'm aware of