### PR TITLE
Hotfix: Consolidated UI, Defaults, and Configuration Tweaks (Batch 1)

### DIFF
--- a/indra/newview/apfloaterphototools.cpp
+++ b/indra/newview/apfloaterphototools.cpp
@@ -776,6 +776,20 @@ bool APFloaterPhototools::postBuild()
     refreshColorBalanceControls(); // Set initial slider/spinner values
     // <AP:WW> ADD END: Initialize Color Balance Mode and Controls
 
+
+    // <AP:WW> ADD THIS BLOCK to connect the Favorites Bar checkbox
+    LLCheckBoxCtrl* favBarCheckboxCtrl = getChild<LLCheckBoxCtrl>("CH_B_Show_Navbar_Favorites");
+    if (favBarCheckboxCtrl) // Still good practice to check if the getChild was successful
+    {
+        // Set its initial state when APS opens
+        favBarCheckboxCtrl->set(gSavedSettings.getBOOL("FSInternalShowNavbarFavoritesPanel")); 
+        
+        // Tell it what function to call when its value changes (i.e., when clicked)
+        favBarCheckboxCtrl->setCommitCallback(boost::bind(&APFloaterPhototools::onAPSShowFavoritesBarToggle, this)); 
+        // // <AP:WW/> Connected APS favorites bar toggle to its handler.
+    }
+    // </AP:WW>
+
     refreshSky();
 
     initCallbacks();
@@ -3379,4 +3393,20 @@ void APFloaterPhototools::onWaterBlurMultipChanged()
 
     LLEnvironment::instance().setEnvironment(LLEnvironment::ENV_LOCAL, current_sky, current_water);
     LLEnvironment::instance().updateEnvironment(LLEnvironment::TRANSITION_INSTANT, true);
+}
+
+void APFloaterPhototools::onAPSShowFavoritesBarToggle()
+{
+    LLCheckBoxCtrl* favBarCheckbox = getChild<LLCheckBoxCtrl>("CH_B_Show_Navbar_Favorites");
+    if (favBarCheckbox)
+    {
+        bool newValue = favBarCheckbox->get();
+
+        gSavedSettings.setBOOL("FSInternalShowNavbarFavoritesPanel", newValue);
+
+        if (gSavedSettings.getBOOL("ShowNavbarFavoritesPanel") != newValue)
+        {
+            gSavedSettings.setBOOL("ShowNavbarFavoritesPanel", newValue);
+        }
+    }
 }

--- a/indra/newview/apfloaterphototools.h
+++ b/indra/newview/apfloaterphototools.h
@@ -106,6 +106,8 @@ public:
     void refreshSky();                         // FEA
     void onEnvironmentUpdated(LLEnvironment::EnvSelection_t env, S32 version);  //FEA
 
+    void onAPSShowFavoritesBarToggle();
+
 private:
     // --- Private Section ---
     // Methods and member variables in this section are only accessible from within the APFloaterPhototools class.

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -1479,7 +1479,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
   <key>OnlineOfflinetoNearbyChatHistory</key>
     <map>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -14663,7 +14663,7 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
     <key>ShowLandHoverTip</key>
     <map>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -14751,7 +14751,7 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
     <key>FSInternalShowNavbarFavoritesPanel</key>
     <map>
@@ -14764,7 +14764,7 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
     <key>ShowNavbarNavigationPanel</key>
     <map>

--- a/indra/newview/app_settings/settings_firestorm.xml
+++ b/indra/newview/app_settings/settings_firestorm.xml
@@ -34,7 +34,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
 
     <key>ChatOnlineNotification</key>

--- a/indra/newview/app_settings/settings_phoenix.xml
+++ b/indra/newview/app_settings/settings_phoenix.xml
@@ -22,7 +22,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
 
     <key>ChatOnlineNotification</key>

--- a/indra/newview/app_settings/settings_text.xml
+++ b/indra/newview/app_settings/settings_text.xml
@@ -34,7 +34,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
 
     <key>ChatOnlineNotification</key>

--- a/indra/newview/featuretable_aperture.txt
+++ b/indra/newview/featuretable_aperture.txt
@@ -118,7 +118,16 @@ RenderSSAOFactor                                    1 1      // Default Factor?
 RenderSSAOIrradianceMax                             1 1.0   // Default Irrad Max?
 RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Scale?
 
-// --- LEVEL 4: DOF SETTINGS ---
+// --- LEVEL 4: SSR (Screen-Space Reflections) SETTINGS ---
+// SSR Enablement
+RenderScreenSpaceReflections                        1 1     // SSR ON
+
+// SSR Quality Details (High Defaults for 'all') 
+RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
+RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
+RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
+
+// --- LEVEL 5: DOF SETTINGS ---
 // DoF Enablement
 RenderDepthOfField                                  1 1     // DoF ON
 
@@ -129,15 +138,6 @@ CameraFocalLength                                   1 500.0  // Standard Lens de
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
 CameraMaxCoF                                        1 150.0  // Default CoC Amount
 CameraDoFResScale                                   1 1.0   // Max DoF Resolution
-
-// --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
-// SSR Enablement
-RenderScreenSpaceReflections                        1 1     // SSR ON
-
-// SSR Quality Details (High Defaults for 'all') 
-RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
-RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
-RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
 
 // --- LEVEL 6: MIRRORS & PLANAR REFLECTION SETTINGS ---
 // Mirror Enablement
@@ -355,7 +355,16 @@ RenderSSAOFactor                                    1 1      // Default Factor?
 RenderSSAOIrradianceMax                             1 1.0   // Default Irrad Max?
 RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Scale?
 
-// --- LEVEL 4: DOF SETTINGS ---
+// --- LEVEL 4: SSR (Screen-Space Reflections) SETTINGS ---
+// SSR Enablement
+RenderScreenSpaceReflections                        1 0     // SSR ON
+
+// SSR Quality Details (High Defaults for 'all') 
+RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
+RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
+RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
+
+// --- LEVEL 5: DOF SETTINGS ---
 // DoF Enablement
 RenderDepthOfField                                  1 0     // DoF ON
 
@@ -366,16 +375,6 @@ CameraFocalLength                                   1 50.0  // Standard Lens def
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
 CameraMaxCoF                                        1 10.0  // Default CoC Amount
 CameraDoFResScale                                   1 0.7   // Max DoF Resolution
-
-// --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
-// SSR Enablement
-RenderScreenSpaceReflections                        1 0     // SSR ON
-
-
-// SSR Quality Details (High Defaults for 'all') 
-RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
-RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
-RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
 
 // --- LEVEL 6: MIRRORS & PLANAR REFLECTION SETTINGS ---
 // Mirror Enablement
@@ -551,7 +550,16 @@ RenderSSAOFactor                                    1 1      // Default Factor?
 RenderSSAOIrradianceMax                             1 1.0   // Default Irrad Max?
 RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Scale?
 
-// --- LEVEL 4: DOF SETTINGS ---
+// --- LEVEL 4: SSR (Screen-Space Reflections) SETTINGS ---
+// SSR Enablement
+RenderScreenSpaceReflections                        1 0     // SSR ON
+
+// SSR Quality Details (High Defaults for 'all') 
+RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
+RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
+RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
+
+// --- LEVEL 5: DOF SETTINGS ---
 // DoF Enablement
 RenderDepthOfField                                  1 0     // DoF ON
 
@@ -562,15 +570,6 @@ CameraFocalLength                                   1 50.0  // Standard Lens def
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
 CameraMaxCoF                                        1 10.0  // Default CoC Amount
 CameraDoFResScale                                   1 0.7   // Max DoF Resolution
-
-// --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
-// SSR Enablement
-RenderScreenSpaceReflections                        1 0     // SSR ON
-
-// SSR Quality Details (High Defaults for 'all') 
-RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
-RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
-RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
 
 // --- LEVEL 6: MIRRORS & PLANAR REFLECTION SETTINGS ---
 // Mirror Enablement
@@ -746,7 +745,16 @@ RenderSSAOFactor                                    1 1      // Default Factor?
 RenderSSAOIrradianceMax                             1 1.0   // Default Irrad Max?
 RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Scale?
 
-// --- LEVEL 4: DOF SETTINGS ---
+// --- LEVEL 4: SSR (Screen-Space Reflections) SETTINGS ---
+// SSR Enablement
+RenderScreenSpaceReflections                        1 0     // SSR ON
+
+// SSR Quality Details (High Defaults for 'all') 
+RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
+RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
+RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
+
+// --- LEVEL 5: DOF SETTINGS ---
 // DoF Enablement
 RenderDepthOfField                                  1 0     // DoF ON
 
@@ -757,16 +765,6 @@ CameraFocalLength                                   1 50.0  // Standard Lens def
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
 CameraMaxCoF                                        1 10.0  // Default CoC Amount
 CameraDoFResScale                                   1 0.7   // Max DoF Resolution
-
-// --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
-// SSR Enablement
-RenderScreenSpaceReflections                        1 0     // SSR ON
-
-
-// SSR Quality Details (High Defaults for 'all') 
-RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
-RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
-RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
 
 // --- LEVEL 6: MIRRORS & PLANAR REFLECTION SETTINGS ---
 // Mirror Enablement
@@ -942,7 +940,16 @@ RenderSSAOFactor                                    1 1      // Default Factor?
 RenderSSAOIrradianceMax                             1 1.0   // Default Irrad Max?
 RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Scale?
 
-// --- LEVEL 4: DOF SETTINGS ---
+// --- LEVEL 4: SSR (Screen-Space Reflections) SETTINGS ---
+// SSR Enablement
+RenderScreenSpaceReflections                        1 0     // SSR ON
+
+// SSR Quality Details (High Defaults for 'all') 
+RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
+RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
+RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
+
+// --- LEVEL 5: DOF SETTINGS ---
 // DoF Enablement
 RenderDepthOfField                                  1 0     // DoF ON
 
@@ -953,11 +960,6 @@ CameraFocalLength                                   1 50.0  // Standard Lens def
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
 CameraMaxCoF                                        1 10.0  // Default CoC Amount
 CameraDoFResScale                                   1 0.7   // Max DoF Resolution
-
-// --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
-// SSR Enablement
-RenderScreenSpaceReflections                        1 0     // SSR ON
-
 
 // SSR Quality Details (High Defaults for 'all') 
 RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
@@ -1046,8 +1048,8 @@ APRenderWhites                                      1 0.0
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
-// list AP_Level_4_DOF: Enables Depth of Field with moderate settings.
-list AP_Level_4_DOF
+// list AP_Level_4_SSR: Enables Screen Space Reflections with moderate settings.
+list AP_Level_4_SSR
 //
 // --- LEVEL 0: ESSENTIAL VISUALS SETTINGS (Always ON / Base Pipeline) ---
 // Core Pipeline & Base Performance
@@ -1138,9 +1140,18 @@ RenderSSAOFactor                                    1 1      // Default Factor?
 RenderSSAOIrradianceMax                             1 1.0   // Default Irrad Max?
 RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Scale?
 
-// --- LEVEL 4: DOF SETTINGS ---
+// --- LEVEL 4: SSR (Screen-Space Reflections) SETTINGS ---
+// SSR Enablement
+RenderScreenSpaceReflections                        1 1     // SSR ON
+
+// SSR Quality Details (High Defaults for 'all') 
+RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
+RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
+RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
+
+// --- LEVEL 5: DOF SETTINGS ---
 // DoF Enablement
-RenderDepthOfField                                  1 1     // DoF ON
+RenderDepthOfField                                  1 0     // DoF ON
 
 // DoF Quality & Behavior (High Defaults for 'all')
 CameraFocusTransitionTime                           1 0.0   // Default Focus Transition
@@ -1149,16 +1160,6 @@ CameraFocalLength                                   1 50.0  // Standard Lens def
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
 CameraMaxCoF                                        1 10.0  // Default CoC Amount
 CameraDoFResScale                                   1 0.7   // Max DoF Resolution
-
-// --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
-// SSR Enablement
-RenderScreenSpaceReflections                        1 0     // SSR ON
-
-
-// SSR Quality Details (High Defaults for 'all') 
-RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
-RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
-RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
 
 // --- LEVEL 6: MIRRORS & PLANAR REFLECTION SETTINGS ---
 // Mirror Enablement
@@ -1242,8 +1243,8 @@ APRenderWhites                                      1 0.0
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
-// list AP_Level_5_SSR: Enables Screen Space Reflections with moderate settings.
-list AP_Level_5_SSR
+// list AP_Level_5_DOF: Enables Depth of Field with moderate settings.
+list AP_Level_5_DOF
 //
 // --- LEVEL 0: ESSENTIAL VISUALS SETTINGS (Always ON / Base Pipeline) ---
 // Core Pipeline & Base Performance
@@ -1334,7 +1335,16 @@ RenderSSAOFactor                                    1 1      // Default Factor?
 RenderSSAOIrradianceMax                             1 1.0   // Default Irrad Max?
 RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Scale?
 
-// --- LEVEL 4: DOF SETTINGS ---
+// --- LEVEL 4: SSR (Screen-Space Reflections) SETTINGS ---
+// SSR Enablement
+RenderScreenSpaceReflections                        1 1     // SSR ON
+
+// SSR Quality Details (High Defaults for 'all') 
+RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
+RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
+RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
+
+// --- LEVEL 5: DOF SETTINGS ---
 // DoF Enablement
 RenderDepthOfField                                  1 1     // DoF ON
 
@@ -1345,16 +1355,6 @@ CameraFocalLength                                   1 50.0  // Standard Lens def
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
 CameraMaxCoF                                        1 10.0  // Default CoC Amount
 CameraDoFResScale                                   1 0.7   // Max DoF Resolution
-
-// --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
-// SSR Enablement
-RenderScreenSpaceReflections                        1 1     // SSR ON
-
-
-// SSR Quality Details (High Defaults for 'all') 
-RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
-RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
-RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
 
 // --- LEVEL 6: MIRRORS & PLANAR REFLECTION SETTINGS ---
 // Mirror Enablement
@@ -1529,7 +1529,16 @@ RenderSSAOFactor                                    1 1      // Default Factor?
 RenderSSAOIrradianceMax                             1 1.0   // Default Irrad Max?
 RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Scale?
 
-// --- LEVEL 4: DOF SETTINGS ---
+// --- LEVEL 4: SSR (Screen-Space Reflections) SETTINGS ---
+// SSR Enablement
+RenderScreenSpaceReflections                        1 1     // SSR ON
+
+// SSR Quality Details (High Defaults for 'all') 
+RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
+RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
+RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
+
+// --- LEVEL 5: DOF SETTINGS ---
 // DoF Enablement
 RenderDepthOfField                                  1 1     // DoF ON
 
@@ -1540,16 +1549,6 @@ CameraFocalLength                                   1 50.0  // Standard Lens def
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
 CameraMaxCoF                                        1 10.0  // Default CoC Amount
 CameraDoFResScale                                   1 0.7   // Max DoF Resolution
-
-// --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
-// SSR Enablement
-RenderScreenSpaceReflections                        1 1     // SSR ON
-
-
-// SSR Quality Details (High Defaults for 'all') 
-RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
-RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
-RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
 
 // --- LEVEL 6: MIRRORS & PLANAR REFLECTION SETTINGS ---
 // Mirror Enablement
@@ -1725,7 +1724,16 @@ RenderSSAOFactor                                    1 1      // Default Factor?
 RenderSSAOIrradianceMax                             1 1.0   // Default Irrad Max?
 RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Scale?
 
-// --- LEVEL 4: DOF SETTINGS ---
+// --- LEVEL 4: SSR (Screen-Space Reflections) SETTINGS ---
+// SSR Enablement
+RenderScreenSpaceReflections                        1 1     // SSR ON
+
+// SSR Quality Details (High Defaults for 'all') 
+RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
+RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
+RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
+
+// --- LEVEL 5: DOF SETTINGS ---
 // DoF Enablement
 RenderDepthOfField                                  1 1     // DoF ON
 
@@ -1736,16 +1744,6 @@ CameraFocalLength                                   1 50.0  // Standard Lens def
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
 CameraMaxCoF                                        1 30.0  // Default CoC Amount
 CameraDoFResScale                                   1 1.0   // Max DoF Resolution
-
-// --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
-// SSR Enablement
-RenderScreenSpaceReflections                        1 1     // SSR ON
-
-
-// SSR Quality Details (High Defaults for 'all') 
-RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
-RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
-RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
 
 // --- LEVEL 6: MIRRORS & PLANAR REFLECTION SETTINGS ---
 // Mirror Enablement
@@ -1918,7 +1916,16 @@ RenderSSAOFactor                                    1 1      // Default Factor?
 RenderSSAOIrradianceMax                             1 1.0   // Default Irrad Max?
 RenderSSAOIrradianceScale                           1 1.0   // Default Irrad Scale?
 
-// --- LEVEL 4: DOF SETTINGS ---
+// --- LEVEL 4: SSR (Screen-Space Reflections) SETTINGS ---
+// SSR Enablement
+RenderScreenSpaceReflections                        1 1     // SSR ON
+
+// SSR Quality Details (High Defaults for 'all') 
+RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
+RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
+RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
+
+// --- LEVEL 5: DOF SETTINGS ---
 // DoF Enablement
 RenderDepthOfField                                  1 1     // DoF ON
 
@@ -1929,16 +1936,6 @@ CameraFocalLength                                   1 50.0  // Standard Lens def
 CameraFieldOfView                                   1 60.0  // Standard FOV default (Separate from Cam Angle)
 CameraMaxCoF                                        1 30.0  // Default CoC Amount
 CameraDoFResScale                                   1 1.0   // Max DoF Resolution
-
-// --- LEVEL 5: SSR (Screen-Space Reflections) SETTINGS ---
-// SSR Enablement
-RenderScreenSpaceReflections                        1 1     // SSR ON
-
-
-// SSR Quality Details (High Defaults for 'all') 
-RenderScreenSpaceReflectionIterations               1 25    // High Iterations default?
-RenderScreenSpaceReflectionRayStep                  1 0.1   // Fine Ray Step default?
-RenderScreenSpaceReflectionGlossySamples            1 1     // High Glossy Samples default - sys default is 4 howeverI see no visual benefit to this. 1 looks the same as 4, the only time this doesn't hold true is on suirfaced water. 
 
 // --- LEVEL 6: MIRRORS & PLANAR REFLECTION SETTINGS ---
 // Mirror Enablement

--- a/indra/newview/llfeaturemanager.cpp
+++ b/indra/newview/llfeaturemanager.cpp
@@ -194,8 +194,8 @@ static const std::vector<std::string> sGraphicsLevelNames = boost::assign::list_
     ("AP_Level_1_HDR_Foundation")      // Level 1
     ("AP_Level_2_Shadows")             // Level 2
     ("AP_Level_3_SSAO")                // Level 3
-    ("AP_Level_4_DOF")                 // Level 4
-    ("AP_Level_5_SSR")                 // Level 5
+    ("AP_Level_4_SSR")                 // Level 4
+    ("AP_Level_5_DOF")                 // Level 5
     ("AP_Level_6_Mirrors")             // Level 6
     ("AP_Level_7_Rich_Candy")          // Level 7
     ("AP_Level_8_Full_Candy")          // Level 8

--- a/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
+++ b/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
@@ -8113,13 +8113,13 @@
                 </check_box>
 
                <check_box
-                 name="CH_B_Show_Grouo_Notices_Top_Right"
+                 name="CH_B_Show_Group_Notices_Top_Right"
                  control_name="ShowGroupNoticesTopRight"
                  height="16"
                  top_pad="0"
                  layout="topleft"
                  left="3"
-                 label="Enable Top-Right Group Notifications (Restart Req.)"
+                 label="Enable Top-Right Group Notices (Restart Req.)"
                  tool_tip=""
                  width="240">
                 </check_box>

--- a/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
+++ b/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
@@ -7234,12 +7234,12 @@
                      name="GP_Ambient_Occlusion"
                      value="3"/>
                     <combo_box.item
-                     label="Depth of Field"
-                     name="GP_Depth_of_Field"
-                     value="4"/>
-                    <combo_box.item
                      label="Screen Space Reflections"
                      name="GP_SSR"
+                     value="4"/>
+                    <combo_box.item
+                     label="Depth of Field"
+                     name="GP_Depth_of_Field"
                      value="5"/>
                     <combo_box.item
                      label="Mirrors"

--- a/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
+++ b/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
@@ -8894,7 +8894,7 @@
                          left="10"
                          font="SansSerif"
                          width="200">
-                            Addtional Camera Options
+                            Additional Camera Options
                         </text>
                     </panel>
 

--- a/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
+++ b/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
@@ -7270,7 +7270,7 @@
              top_pad="0"
              left="0"
              width="286"
-             height="122"
+             height="117"
              border_visible="true"
              bevel_style="none"
              background_visible="true">
@@ -8132,6 +8132,18 @@
                  layout="topleft"
                  left="3"
                  label="Enable Nearby Chat Online/Offline Notices"
+                 tool_tip=""
+                 width="240">
+                </check_box>
+
+               <check_box
+                 name="CH_B_Show_Navbar_Favorites"
+                 control_name="FSInternalShowNavbarFavoritesPanel"
+                 height="16"
+                 top_pad="0"
+                 layout="topleft"
+                 left="3"
+                 label="Enable Favorites Bar (Nav Bar)"
                  tool_tip=""
                  width="240">
                 </check_box>

--- a/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
+++ b/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
@@ -6728,7 +6728,7 @@
              top_pad="0"
              left="0"
              width="286"
-             height="235" 
+             height="257" 
              border_visible="true"
              bevel_style="none"
              background_visible="true">
@@ -6801,6 +6801,42 @@
                      parameter="character"/>
                 </check_box>
 
+                <text
+                 name="T_NAME"
+                 follows="left|top"
+                 height="20"
+                 left="5"
+                 v_pad="5"
+                 tool_tip=""
+                 top_pad="3"
+                 width="132"
+                 layout="topleft">
+                    Name Tag Display
+                </text>
+
+                <combo_box
+                 name="CB_Avatar_Name_Tag_Mode"
+                 control_name="AvatarNameTagMode"
+                 layout="topleft"
+                 follows="left|top"
+                 left_pad="0"
+                 top_delta="0"
+                 height="20"
+                 width="146"
+               >
+                    <combo_box.item
+                     label="Off"
+                     name="0"
+                     value="0"/>
+                    <combo_box.item
+                     label="On"
+                     name="1"
+                     value="1"/>
+                    <combo_box.item
+                     label="Show Briefly"
+                     name="2"
+                     value="2"/>
+                </combo_box>
 
                 <text
                  name="T_AvatarDisplay"
@@ -8156,42 +8192,7 @@
                  tool_tip="Reset to the default value.">
                 </button>
 
-                <text
-                 name="T_NAME"
-                 follows="left|top"
-                 height="20"
-                 left="5"
-                 v_pad="5"
-                 tool_tip=""
-                 top_pad="3"
-                 width="162"
-                 layout="topleft">
-                    Name Tag Display
-                </text>
 
-                <combo_box
-                 name="CB_Avatar_Name_Tag_Mode"
-                 control_name="AvatarNameTagMode"
-                 layout="topleft"
-                 follows="left|top"
-                 left_pad="0"
-                 top_delta="0"
-                 height="20"
-                 width="116"
-               >
-                    <combo_box.item
-                     label="Off"
-                     name="0"
-                     value="0"/>
-                    <combo_box.item
-                     label="On"
-                     name="1"
-                     value="1"/>
-                    <combo_box.item
-                     label="Show Briefly"
-                     name="2"
-                     value="2"/>
-                </combo_box>
 <!--
                 <button
                  follows="left|top"

--- a/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
+++ b/indra/newview/skins/default/xui/en/floater_ap_phototools.xml
@@ -8124,6 +8124,17 @@
                  width="240">
                 </check_box>
 
+               <check_box
+                 name="CH_B_Online_Offline_Notices"
+                 control_name="OnlineOfflinetoNearbyChat"
+                 height="16"
+                 top_pad="0"
+                 layout="topleft"
+                 left="3"
+                 label="Enable Nearby Chat Online/Offline Notices"
+                 tool_tip=""
+                 width="240">
+                </check_box>
 
 <!--
                 <check_box

--- a/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_graphics1.xml
@@ -280,12 +280,12 @@
                      name="GP_Ambient_Occlusion"
                      value="3"/>
                     <combo_box.item
-                     label="Level 5 - Depth of Field"
-                     name="GP_Depth_of_Field"
+                     label="Level 5 - Screen Space Reflections"
+                     name="GP_SSR"
                      value="4"/>
                     <combo_box.item
-                     label="Level 6 - Screen Space Reflections"
-                     name="GP_SSR"
+                     label="Level 6 - Depth of Field"
+                     name="GP_Depth_of_Field"
                      value="5"/>
                     <combo_box.item
                      label="Level 7 - Mirrors"


### PR DESCRIPTION
**Title:** Hotfix: Consolidated UI, Defaults, and Configuration Tweaks (Batch 1)

**Description:**

This Pull Request includes a batch of 7 targeted hotfixes, UI enhancements, and configuration adjustments to address user feedback and improve the overall viewer experience. These changes have been consolidated into a single PR to streamline the QA process. Each commit addresses a specific issue.

A build containing these changes will be provided for QA. Please test each item based on its corresponding issue description and the detailed testing steps outlined below for each commit.

---

**Changes Included & Testing Steps:**

**1. Commit `9ad226c8af`: Refactor: Relocate 'Name Tag Display' to APS Avatar Tab**
   - *Summary:* Moved the "Name Tag Display" setting (text label and combo box) from the Aperture Phototools Suite (APS) "General" tab to the "Avatar" tab for better logical grouping.
   - *Issue(s):* Resolves #38

   - **Testing:**
     - Open APS (Alt+P).
     - Verify "Name Tag Display" is no longer present in the General tab.
     - Verify "Name Tag Display" is now present and correctly positioned in the Avatar tab.
     - Test functionality: confirmed that changing the selection in the combo box (Off, On, Show Briefly) correctly updates the `AvatarNameTagMode` setting and affects name tag visibility in-world.

**2. Commit `49e746e4ca`: Fixes: Correct typo in APS Cam tab header**
   - *Summary:* Corrected a typographical error in the APS "Cam" tab section header from "Addtional Camera Options" to "Additional Camera Options".
   - *Issue(s):* Fixes #13

   - **Testing:**
     - Open APS (Alt+P).
     - Navigate to the "Cam" tab.
     - Verify the header now correctly reads "Additional Camera Options".

**3. Commit `d475564394`: Fixes: Abbreviate Group Notices label & fix name typo in APS**
   - *Summary:* Corrected a typo in the `name` attribute of the "Group Notifications" checkbox and abbreviated its `label` for better UI fit in the APS General tab. Tooltip was also updated.
   - *Issue(s):* Fixes #37

   - **Testing:**
     - Open APS (Alt+P) and navigate to the General tab.
     - Verify the checkbox label for group notices (now "Top-Right Group Notices (Restart Req.)" or similar) is shortened and fits correctly.
     - Verify the `name` attribute in `floater_ap_phototools.xml` is `CH_B_Show_Group_Notices_Top_Right`.
     - Ensure the checkbox functionality remains intact by toggling the `ShowGroupNoticesTopRight` setting.

**4. Commit `7f3389071d`: Fixes & Enhance: Default chat notices to ON & add APS toggle**
   - *Summary:* Reverted the default state of 'OnlineOfflinetoNearbyChat' to true (enabled) across relevant settings files. Added a checkbox to the APS General tab to control this setting.
   - *Issue(s):* Resolves #33, Resolves #35 

   - **Testing:**
     - **Default Behavior:** Perform a clean install or reset viewer settings to default. Verify online/offline friend notifications appear in Nearby Chat by default.
     - **APS Toggle:**
       - Open APS (Alt+P) -> General tab.
       - Verify the new "Enable Nearby Chat Online/Offline Notices" checkbox is present.
       - Verify the setting persists across viewer restarts when changed via the APS toggle.
       - Ensure other UI elements (like any old preferences toggle for this) reflect changes made via APS and vice-versa.

**5. Commit `3f510db7ea`: Fixes & Enhance: Default Favorites Bar to ON & add APS toggle**
   - *Summary:* Reverted 'FSInternalShowNavbarFavoritesPanel' in `settings.xml` to true so the Favorites Bar is visible by default. Added a checkbox "Enable Favorites Bar (Nav Bar)" to the APS General tab to control this, ensuring sync with `ShowNavbarFavoritesPanel` for World Menu/Prefs compatibility.
   - *Issue(s):* Resolves #34 

   - **Testing:**
     - **Default Behavior:** Verify Favorites Bar is visible by default on fresh settings.
     - **APS Toggle:**
       - Open APS (Alt+P) -> General tab. Test the "Enable Favorites Bar (Nav Bar)" checkbox.
       - Confirm it correctly shows/hides the Favorites Bar on the Nav Bar.
       - Confirm its state reflects the actual setting on APS load.
       - Verify the setting persists across viewer restarts.
     - **Synchronization:**
       - Toggle the setting via APS. Verify the visual state (checkmark) of the "Show Favorites Bar" item in the World menu and the checkbox in Preferences -> UI are updated.
       - Toggle the setting from the World Menu or Preferences. Verify the state of the APS checkbox is updated when APS is next opened.

**6. Commit `acbfb7ca90`: Refactor: Adjust graphics preset order for SSR and DoF**
   - *Summary:* Modified `featuretable_aperture.txt`, `llfeaturemanager.cpp`, and UI XMLE (APS & Prefs) to change the order in which Screen-Space Reflections (SSR) and Depth of Field (DoF) are enabled. SSR is now at AP Level 4, DoF at AP Level 5.
   - *Issue(s):* Resolves #36 

   - **Testing:**
     - Launch viewer and navigate to Preferences -> Graphics and Aperture Phototools (Alt+P) -> General tab.
     - Sequentially select each AP graphics preset level (0-8) via both UI locations.
     - Verify via debug settings (`RenderScreenSpaceReflections`, `RenderDepthOfField`):
         - Level 4 and below: SSR OFF, DoF OFF.
         - Level 5 (new SSR): SSR ON, DoF OFF.
         - Level 6 (new DoF): SSR ON, DoF ON.
         - Levels 7-9: SSR ON, DoF ON.
     - Confirm combo box labels in UI reflect the new order and descriptions for levels 4 & 5.
     - Check the same in the Preferences Graphics tab (checking correct order and loading).

**7. Commit `46baaea9ee`: Fixes: Enable Basic UI Tooltips by default**
   - *Summary:* Changed the default value for the 'BasicUITooltips' setting to true (1) in `settings.xml` to re-enable hover tooltips by default.
   - *Issue(s):* Fixes #32

   - **Testing:**
     - Launch viewer with fresh settings (user settings folder removed/renamed).
     - Verify that hovering over various UI buttons, checkboxes, and other elements displays tooltips by default.
     - Confirm that existing preferences (if any) to disable tooltips still function correctly.

---
Please proceed with QA. Thank you!