### PR TITLE
Fixes & Refactor: Default settings and featuretable adjustments for Issues #45 & #50

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -345,7 +345,7 @@
         <key>Type</key>             
         <string>F32</string>        
         <key>Value</key>               
-        <integer>8</integer>          
+        <integer>8.0</integer>          
     </map>
     <key>APPhototoolsShowOnlyMySettings</key>
     <map>
@@ -1135,7 +1135,7 @@
     <key>Type</key>
     <string>Boolean</string>
     <key>Value</key>
-    <integer>1</integer>
+    <integer>0</integer>
   </map>
 
   <key>InternalShowGroupNoticesTopRight</key>
@@ -1149,7 +1149,7 @@
     <key>Type</key>
     <string>Boolean</string>
     <key>Value</key>
-    <integer>0</integer>
+    <integer>1</integer>
   </map>
 
   <key>FirstUseFlyOverride</key>
@@ -1471,7 +1471,7 @@
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>1</integer>
+      <integer>0</integer>
     </map>
   <key>OnlineOfflinetoNearbyChatHistory</key>
     <map>
@@ -7497,7 +7497,7 @@
       <key>Comment</key>
       <string>Version number of cache</string>
       <key>Persist</key>
-      <integer>0</integer>
+      <integer>1</integer>
       <key>Type</key>
       <string>S32</string>
       <key>Value</key>
@@ -13935,7 +13935,7 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
     <key>RenderShaderCacheVersion</key>
     <map>
@@ -15907,7 +15907,7 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Type</key>
       <string>F32</string>
       <key>Value</key>
-      <real>100000.0</real>
+      <real>3000.0</real>
     </map>
     <key>ToolTipDelay</key>
     <map>

--- a/indra/newview/featuretable_aperture.txt
+++ b/indra/newview/featuretable_aperture.txt
@@ -39,11 +39,12 @@ RenderAutoMaskAlphaNonDeferred                      1 1     // Render alpha mask
 RenderObjectBump                                    1 1     // <<< LEVEL 1 CHANGE: only Suported true for? ON
 RenderDeferred                                      1 1     // <<< LEVEL 1 CHANGE: Only Supported True  for? ON 
 RenderGLContextCoreProfile                          1 0     // Should consider leaving this off at all times as we are not sure the codebase is cleaned for all APIs?
+RenderCubeMap                                       1 1
 
 // --- LEVEL 1: HDR FOUNDATION, REFLECTION PROBES & GLOW SETTINGS ---
 // Core Pipeline & Base Performance
-RenderGLMultiThreadedMedia                          1 1     // Default ON
-RenderGLMultiThreadedTextures                       1 1     // Default ON
+RenderGLMultiThreadedMedia                          1 1     // Default OFF
+RenderGLMultiThreadedTextures                       1 1     // Default OFF
 UseOcclusion                                        1 1     // Occlusion Culling ON
 
 
@@ -169,7 +170,7 @@ RenderVolumeLODFactor                               1 8.0   // Object/Volume LOD
 // Textures (Max Quality Defaults)
 RenderMaxTextureResolution                          1 2048  // Max Texture Res (only at level 0 we set to 512)
 TextureDiscardLevel                                 1 0     // Tex Discard (0=Off) - it is off by default and should always be (maybe not in level 0)
-TextureCameraBoost                                  1 8     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
+TextureCameraBoost                                  1 7.0     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
 
 // Culling Thresholds (Generous Defaults for 'all')
 RenderAutoMuteSurfaceAreaLimit                      1 0     // Must be set to 0 for RenderAvatarComplexityMode to work properly
@@ -277,6 +278,7 @@ RenderAutoMaskAlphaNonDeferred                      1 1     // Render alpha mask
 RenderObjectBump                                    1 1     // <<< LEVEL 1 CHANGE: only Suported true for? ON
 RenderDeferred                                      1 1     // <<< LEVEL 1 CHANGE: Only Supported True  for? ON 
 RenderGLContextCoreProfile                          1 0     // Should consider leaving this off at all times as we are not sure the codebase is cleaned for all APIs?
+RenderCubeMap                                       1 1
 
 // --- LEVEL 1: HDR FOUNDATION, REFLECTION PROBES & GLOW SETTINGS ---
 // Core Pipeline & Base Performance
@@ -406,7 +408,7 @@ RenderVolumeLODFactor                               1 1.0   // Object/Volume LOD
 // Textures (Max Quality Defaults)
 RenderMaxTextureResolution                          1 512  // Max Texture Res (only at level 0 we set to 512)
 TextureDiscardLevel                                 1 0     // Tex Discard (0=Off) - it is off by default and should always be (maybe not in level 0)
-TextureCameraBoost                                  1 8     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
+TextureCameraBoost                                  1 7.0     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
 
 // Culling Thresholds (Generous Defaults for 'all')
 RenderAutoMuteSurfaceAreaLimit                      1 0     // Must be set to 0 for RenderAvatarComplexityMode to work properly
@@ -472,11 +474,12 @@ RenderAutoMaskAlphaNonDeferred                      1 1     // Render alpha mask
 RenderObjectBump                                    1 1     // <<< LEVEL 1 CHANGE: only Suported true for? ON
 RenderDeferred                                      1 1     // <<< LEVEL 1 CHANGE: Only Supported True  for? ON 
 RenderGLContextCoreProfile                          1 0     // Should consider leaving this off at all times as we are not sure the codebase is cleaned for all APIs?
+RenderCubeMap                                       1 1
 
 // --- LEVEL 1: HDR FOUNDATION, REFLECTION PROBES & GLOW SETTINGS ---
 // Core Pipeline & Base Performance
-RenderGLMultiThreadedMedia                          1 1     // Default ON
-RenderGLMultiThreadedTextures                       1 1     // Default ON
+RenderGLMultiThreadedMedia                          1 0     // Default ON
+RenderGLMultiThreadedTextures                       1 0     // Default ON
 UseOcclusion                                        1 1     // Occlusion Culling ON
 
 // HDR Enablement & Core Settings
@@ -601,7 +604,7 @@ RenderVolumeLODFactor                               1 8.0   // Object/Volume LOD
 // Textures (Max Quality Defaults)
 RenderMaxTextureResolution                          1 2048  // Max Texture Res (only at level 0 we set to 512)
 TextureDiscardLevel                                 1 0     // Tex Discard (0=Off) - it is off by default and should always be (maybe not in level 0)
-TextureCameraBoost                                  1 8     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
+TextureCameraBoost                                  1 7.0     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
 
 // Culling Thresholds (Generous Defaults for 'all')
 RenderAutoMuteSurfaceAreaLimit                      1 0     // Must be set to 0 for RenderAvatarComplexityMode to work properly
@@ -667,11 +670,12 @@ RenderAutoMaskAlphaNonDeferred                      1 1     // Render alpha mask
 RenderObjectBump                                    1 1     // <<< LEVEL 1 CHANGE: only Suported true for? ON
 RenderDeferred                                      1 1     // <<< LEVEL 1 CHANGE: Only Supported True  for? ON 
 RenderGLContextCoreProfile                          1 0     // Should consider leaving this off at all times as we are not sure the codebase is cleaned for all APIs?
+RenderCubeMap                                       1 1
 
 // --- LEVEL 1: HDR FOUNDATION, REFLECTION PROBES & GLOW SETTINGS ---
 // Core Pipeline & Base Performance
-RenderGLMultiThreadedMedia                          1 1     // Default ON
-RenderGLMultiThreadedTextures                       1 1     // Default ON
+RenderGLMultiThreadedMedia                          1 0     // Default ON
+RenderGLMultiThreadedTextures                       1 0     // Default ON
 UseOcclusion                                        1 1     // Occlusion Culling ON
 
 // HDR Enablement & Core Settings
@@ -796,7 +800,7 @@ RenderVolumeLODFactor                               1 8.0   // Object/Volume LOD
 // Textures (Max Quality Defaults)
 RenderMaxTextureResolution                          1 2048  // Max Texture Res (only at level 0 we set to 512)
 TextureDiscardLevel                                 1 0     // Tex Discard (0=Off) - it is off by default and should always be (maybe not in level 0)
-TextureCameraBoost                                  1 8     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
+TextureCameraBoost                                  1 7.0     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
 
 // Culling Thresholds (Generous Defaults for 'all')
 RenderAutoMuteSurfaceAreaLimit                      1 0     // Must be set to 0 for RenderAvatarComplexityMode to work properly
@@ -861,11 +865,12 @@ RenderAutoMaskAlphaNonDeferred                      1 1     // Render alpha mask
 RenderObjectBump                                    1 1     // <<< LEVEL 1 CHANGE: only Suported true for? ON
 RenderDeferred                                      1 1     // <<< LEVEL 1 CHANGE: Only Supported True  for? ON 
 RenderGLContextCoreProfile                          1 0     // Should consider leaving this off at all times as we are not sure the codebase is cleaned for all APIs?
+RenderCubeMap                                       1 1
 
 // --- LEVEL 1: HDR FOUNDATION, REFLECTION PROBES & GLOW SETTINGS ---
 // Core Pipeline & Base Performance
-RenderGLMultiThreadedMedia                          1 1     // Default ON
-RenderGLMultiThreadedTextures                       1 1     // Default ON
+RenderGLMultiThreadedMedia                          1 0     // Default ON
+RenderGLMultiThreadedTextures                       1 0     // Default ON
 UseOcclusion                                        1 1     // Occlusion Culling ON
 
 // HDR Enablement & Core Settings
@@ -996,7 +1001,7 @@ RenderVolumeLODFactor                               1 8.0   // Object/Volume LOD
 // Textures (Max Quality Defaults)
 RenderMaxTextureResolution                          1 2048  // Max Texture Res (only at level 0 we set to 512)
 TextureDiscardLevel                                 1 0     // Tex Discard (0=Off) - it is off by default and should always be (maybe not in level 0)
-TextureCameraBoost                                  1 8     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
+TextureCameraBoost                                  1 7.0     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
 
 // Culling Thresholds (Generous Defaults for 'all')
 RenderAutoMuteSurfaceAreaLimit                      1 0     // Must be set to 0 for RenderAvatarComplexityMode to work properly
@@ -1062,11 +1067,12 @@ RenderAutoMaskAlphaNonDeferred                      1 1     // Render alpha mask
 RenderObjectBump                                    1 1     // <<< LEVEL 1 CHANGE: only Suported true for? ON
 RenderDeferred                                      1 1     // <<< LEVEL 1 CHANGE: Only Supported True  for? ON 
 RenderGLContextCoreProfile                          1 0     // Should consider leaving this off at all times as we are not sure the codebase is cleaned for all APIs?
+RenderCubeMap                                       1 1
 
 // --- LEVEL 1: HDR FOUNDATION, REFLECTION PROBES & GLOW SETTINGS ---
 // Core Pipeline & Base Performance
-RenderGLMultiThreadedMedia                          1 1     // Default ON
-RenderGLMultiThreadedTextures                       1 1     // Default ON
+RenderGLMultiThreadedMedia                          1 0     // Default ON
+RenderGLMultiThreadedTextures                       1 0     // Default ON
 UseOcclusion                                        1 1     // Occlusion Culling ON
 
 // HDR Enablement & Core Settings
@@ -1191,7 +1197,7 @@ RenderVolumeLODFactor                               1 8.0   // Object/Volume LOD
 // Textures (Max Quality Defaults)
 RenderMaxTextureResolution                          1 2048  // Max Texture Res (only at level 0 we set to 512)
 TextureDiscardLevel                                 1 0     // Tex Discard (0=Off) - it is off by default and should always be (maybe not in level 0)
-TextureCameraBoost                                  1 8     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
+TextureCameraBoost                                  1 7.0     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
 
 // Culling Thresholds (Generous Defaults for 'all')
 RenderAutoMuteSurfaceAreaLimit                      1 0     // Must be set to 0 for RenderAvatarComplexityMode to work properly
@@ -1257,11 +1263,12 @@ RenderAutoMaskAlphaNonDeferred                      1 1     // Render alpha mask
 RenderObjectBump                                    1 1     // <<< LEVEL 1 CHANGE: only Suported true for? ON
 RenderDeferred                                      1 1     // <<< LEVEL 1 CHANGE: Only Supported True  for? ON 
 RenderGLContextCoreProfile                          1 0     // Should consider leaving this off at all times as we are not sure the codebase is cleaned for all APIs?
+RenderCubeMap                                       1 1
 
 // --- LEVEL 1: HDR FOUNDATION, REFLECTION PROBES & GLOW SETTINGS ---
 // Core Pipeline & Base Performance
-RenderGLMultiThreadedMedia                          1 1     // Default ON
-RenderGLMultiThreadedTextures                       1 1     // Default ON
+RenderGLMultiThreadedMedia                          1 0     // Default ON
+RenderGLMultiThreadedTextures                       1 0     // Default ON
 UseOcclusion                                        1 1     // Occlusion Culling ON
 
 // HDR Enablement & Core Settings
@@ -1386,7 +1393,7 @@ RenderVolumeLODFactor                               1 8.0   // Object/Volume LOD
 // Textures (Max Quality Defaults)
 RenderMaxTextureResolution                          1 2048  // Max Texture Res (only at level 0 we set to 512)
 TextureDiscardLevel                                 1 0     // Tex Discard (0=Off) - it is off by default and should always be (maybe not in level 0)
-TextureCameraBoost                                  1 8     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
+TextureCameraBoost                                  1 7.0     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
 
 // Culling Thresholds (Generous Defaults for 'all')
 RenderAutoMuteSurfaceAreaLimit                      1 0     // Must be set to 0 for RenderAvatarComplexityMode to work properly
@@ -1451,11 +1458,12 @@ RenderAutoMaskAlphaNonDeferred                      1 1     // Render alpha mask
 RenderObjectBump                                    1 1     // <<< LEVEL 1 CHANGE: only Suported true for? ON
 RenderDeferred                                      1 1     // <<< LEVEL 1 CHANGE: Only Supported True  for? ON 
 RenderGLContextCoreProfile                          1 0     // Should consider leaving this off at all times as we are not sure the codebase is cleaned for all APIs?
+RenderCubeMap                                       1 1
 
 // --- LEVEL 1: HDR FOUNDATION, REFLECTION PROBES & GLOW SETTINGS ---
 // Core Pipeline & Base Performance
-RenderGLMultiThreadedMedia                          1 1     // Default ON
-RenderGLMultiThreadedTextures                       1 1     // Default ON
+RenderGLMultiThreadedMedia                          1 0     // Default ON
+RenderGLMultiThreadedTextures                       1 0     // Default ON
 UseOcclusion                                        1 1     // Occlusion Culling ON
 
 // HDR Enablement & Core Settings
@@ -1580,7 +1588,7 @@ RenderVolumeLODFactor                               1 8.0   // Object/Volume LOD
 // Textures (Max Quality Defaults)
 RenderMaxTextureResolution                          1 2048  // Max Texture Res (only at level 0 we set to 512)
 TextureDiscardLevel                                 1 0     // Tex Discard (0=Off) - it is off by default and should always be (maybe not in level 0)
-TextureCameraBoost                                  1 8     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
+TextureCameraBoost                                  1 7.0     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
 
 // Culling Thresholds (Generous Defaults for 'all')
 RenderAutoMuteSurfaceAreaLimit                      1 0     // Must be set to 0 for RenderAvatarComplexityMode to work properly
@@ -1646,11 +1654,12 @@ RenderAutoMaskAlphaNonDeferred                      1 1     // Render alpha mask
 RenderObjectBump                                    1 1     // <<< LEVEL 1 CHANGE: only Suported true for? ON
 RenderDeferred                                      1 1     // <<< LEVEL 1 CHANGE: Only Supported True  for? ON 
 RenderGLContextCoreProfile                          1 0     // Should consider leaving this off at all times as we are not sure the codebase is cleaned for all APIs?
+RenderCubeMap                                       1 1
 
 // --- LEVEL 1: HDR FOUNDATION, REFLECTION PROBES & GLOW SETTINGS ---
 // Core Pipeline & Base Performance
-RenderGLMultiThreadedMedia                          1 1     // Default ON
-RenderGLMultiThreadedTextures                       1 1     // Default ON
+RenderGLMultiThreadedMedia                          1 0     // Default ON
+RenderGLMultiThreadedTextures                       1 0     // Default ON
 UseOcclusion                                        1 1     // Occlusion Culling ON
 
 // HDR Enablement & Core Settings
@@ -1775,7 +1784,7 @@ RenderVolumeLODFactor                               1 8.0   // Object/Volume LOD
 // Textures (Max Quality Defaults)
 RenderMaxTextureResolution                          1 2048  // Max Texture Res (only at level 0 we set to 512)
 TextureDiscardLevel                                 1 0     // Tex Discard (0=Off) - it is off by default and should always be (maybe not in level 0)
-TextureCameraBoost                                  1 8     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
+TextureCameraBoost                                  1 7.0     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
 
 // Culling Thresholds (Generous Defaults for 'all')
 RenderAutoMuteSurfaceAreaLimit                      1 0     // Must be set to 0 for RenderAvatarComplexityMode to work properly
@@ -1838,11 +1847,12 @@ RenderAutoMaskAlphaNonDeferred                      1 1     // Render alpha mask
 RenderObjectBump                                    1 1     // <<< LEVEL 1 CHANGE: only Suported true for? ON
 RenderDeferred                                      1 1     // <<< LEVEL 1 CHANGE: Only Supported True  for? ON 
 RenderGLContextCoreProfile                          1 0     // Should consider leaving this off at all times as we are not sure the codebase is cleaned for all APIs?
+RenderCubeMap                                       1 1
 
 // --- LEVEL 1: HDR FOUNDATION, REFLECTION PROBES & GLOW SETTINGS ---
 // Core Pipeline & Base Performance
-RenderGLMultiThreadedMedia                          1 1     // Default ON
-RenderGLMultiThreadedTextures                       1 1     // Default ON
+RenderGLMultiThreadedMedia                          1 0     // Default ON
+RenderGLMultiThreadedTextures                       1 0     // Default ON
 UseOcclusion                                        1 1     // Occlusion Culling ON
 
 // HDR Enablement & Core Settings
@@ -1967,7 +1977,7 @@ RenderVolumeLODFactor                               1 8.0   // Object/Volume LOD
 // Textures (Max Quality Defaults)
 RenderMaxTextureResolution                          1 2048  // Max Texture Res (only at level 0 we set to 512)
 TextureDiscardLevel                                 1 0     // Tex Discard (0=Off) - it is off by default and should always be (maybe not in level 0)
-TextureCameraBoost                                  1 8     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
+TextureCameraBoost                                  1 7.0     // Tex Boost Near Cam (Need to investigate further this is a scaler for priority of texture loading near camera - see investigation notes.)
 
 // Culling Thresholds (Generous Defaults for 'all')
 RenderAutoMuteSurfaceAreaLimit                      1 0     // Must be set to 0 for RenderAvatarComplexityMode to work properly


### PR DESCRIPTION
This Pull Request introduces a series of default setting adjustments in `settings.xml` and refactors `featuretable_aperture.txt`. These changes are primarily aimed at establishing a more stable and consistent baseline for investigating and potentially mitigating texture loading problems (Issue #45 - grey avatar attachments) and slow/incomplete inventory re-loads on startup for large inventories (Issue #50). Additionally, some changes enhance the general out-of-the-box user experience and ensure type consistency.

**Summary of Changes:**

**1. `settings.xml` Adjustments (Commit `d248e29700`):**
   *   **Targeting Issue #45 & #50 Investigation:**
       *   `RenderShaderCacheEnabled` defaulted to `true` to test improvements in texture/asset loading reliability.
       *   `ThrottleBandwidthKBPS` adjusted to `3000.0` (from `100000.0`) as a more sensible default that might positively impact texture/inventory fetching.
       *   Enabled persistence for `LocalCacheVersion` for overall cache integrity, potentially aiding reliable loading of cached inventory (Issue #50) and assets.
   *   **User Experience & Firestorm Familiarity:**
       *   `ShowGroupNoticesTopRight` defaulted to `false` and `InternalShowGroupNoticesTopRight` to `true` for standardized/familiar group notice display.
       *   `OnlineOfflinetoNearbyChat` defaulted to `false` to reduce chat clutter.
   *   **Corrections:**
       *   `APRenderSSAOSampleCount` corrected from integer `8` to float `8.0` for type consistency.

**2. `featuretable_aperture.txt` Refactor (Commit `6d277d6b94`):**
   *   Applied to the 'all' list and all AP_Level_0 through AP_Level_8 presets:
       *   Added `RenderCubeMap 1 1` to ensure cubemap rendering is enabled by default.
       *   Changed `RenderGLMultiThreadedMedia` and `RenderGLMultiThreadedTextures` recommended values from `1` (enabled) to `0` (disabled by default in presets). This is a diagnostic step for Issues #45 & #50 to see if disabling these by default in presets improves stability.
       *   Standardized `TextureCameraBoost` recommended value to `7.0`, identified as a potentially more stable/optimal value during investigations related to texture loading behavior (Issue #45).

**Testing Required (On this `tmp_texture_bug_investigation` branch, *before* merging to `dev`):**
*   Continued monitoring of texture loading behavior, especially concerning Issue #45. Users who frequently experience grey attachments should test this branch.
*   Specific testing by users with large inventories (who have previously experienced slow re-loads per Issue #50) to assess any impact on inventory loading times/completeness on subsequent viewer startups after an initial cache population with this branch.
*   Confirmation that user experience changes (notice positions, online/offline chat notifications) are as expected*.
*   General stability testing across various scenarios.

**Related Issues:**
*   Addresses investigation steps for #45
*   Addresses investigation steps for #50