### PR TITLE
Feature #52: Increase MAX_SNAPSHOT_IMAGE_SIZE to 32768

### DIFF
--- a/indra/newview/llviewerwindow.h
+++ b/indra/newview/llviewerwindow.h
@@ -144,11 +144,8 @@ private:
 
 };
       
-// <FS:WWeaver/> increase max snapshot image size to 8192 for higher resolution snapshots
-// static const U32 MAX_SNAPSHOT_IMAGE_SIZE = 8096; // max snapshot image size 8096 * 8096 UHDTV2
-static const U32 MAX_SNAPSHOT_IMAGE_SIZE = 8192; // max snapshot image size 8192* 8192
-// </FS:WW>
-    
+static const U32 MAX_SNAPSHOT_IMAGE_SIZE = 32768; // <AP:WW> Raised max snapshot image size 32768 * 32768
+
 class LLViewerWindow : public LLWindowCallbacks
 {
 public:


### PR DESCRIPTION
This PR implements Feature Request #52, increasing the `MAX_SNAPSHOT_IMAGE_SIZE` constant in `llviewerwindow.h` from `8192` to `32768`.

**Purpose:**
To allow users, particularly virtual photographers, to capture snapshots at extremely high resolutions (up to 32768x32768 pixels) for purposes such as large prints or detailed post-processing.

**Commit Included:**
*   The single commit on this branch increases `MAX_SNAPSHOT_IMAGE_SIZE`.

**Important Considerations & Risks (as detailed in Issue #52):**
*   **Extreme Memory Consumption:** Snapshots at maximum resolution will require significant VRAM and system RAM (approx. 4GB for the framebuffer at 32k RGBA, plus overhead).
*   **High Stability Risk:** Crashes, system slowdowns, and out-of-memory errors are highly probable when attempting to use resolutions near the new limit, especially on systems not equipped with top-tier GPUs and abundant RAM.
*   **Performance:** Snapshot generation will be slow at these sizes.
*   **Hardware Limits:** GPU hardware may have its own render target dimension limits.

**USER DISCLAIMER:**
This is an experimental feature intended for advanced users with very high-end hardware. Users attempting to render snapshots at extreme resolutions (approaching 32768x32768) do so **ENTIRELY AT THEIR OWN RISK.** Aperture Viewer development is not responsible for any viewer crashes, system instability, data loss that may occur or any other software or hardware consequence. It is strongly advised to save all work and test with incrementally larger resolutions.

**Testing Performed by Committer (Locally on this branch):**
*   Viewer compiled successfully with the new constant.
*   Snapshot UI ("Save to Disk" floater) allows input of dimensions up to 32768.
*   Basic snapshot functionality confirmed at moderately high resolutions (below the new maximum) on a capable system.

**Further Testing Required (On this branch, *before* merging to `dev`):**
*   Systematic testing of snapshot stability at various large dimensions (e.g., 12k, 16k, 24k, 32k) on high-end hardware (e.g., RTX 3090/4090).
*   Document the practical stable limits observed on test hardware.
*   Verify image integrity of successfully captured ultra-high-resolution snapshots.
*   Communicate the risks and experimental nature clearly to any testers.

**Related Issue:** Closes #52